### PR TITLE
Adding a new endpoint should allow the response HttpStatus to be set

### DIFF
--- a/EndpointForge.WebApi/Models/EndpointForgeDataSource.cs
+++ b/EndpointForge.WebApi/Models/EndpointForgeDataSource.cs
@@ -7,14 +7,23 @@ public class EndpointForgeDataSource : MutableEndpointDataSource, IEndpointForge
 {
     public void AddEndpoint(AddEndpointRequest addEndpointRequest, bool apply = true)
     {
-        var (pattern, _, priority) = addEndpointRequest;
-        var endpoint = new RouteEndpointBuilder(BuildResponse, RoutePatternFactory.Parse(pattern), priority)
+        var (pattern, method, response, priority) = addEndpointRequest;
+        //var response = addEndpointRequest.Response ?? new EndpointRequestResponse(200);
+        var endpoint = new RouteEndpointBuilder(
+                BuildResponse(response ?? new EndpointRequestResponse(200)), 
+                RoutePatternFactory.Parse(pattern), 
+                priority)
             {
-                Metadata = { new HttpMethodMetadata([addEndpointRequest.Method]) }
+                Metadata = { new HttpMethodMetadata([method]) }
             }
             .Build();
         base.AddEndpoint(endpoint, apply);
     }
 
-    private static RequestDelegate BuildResponse => async _ => await Task.FromResult(TypedResults.Ok());
+    private static RequestDelegate BuildResponse(EndpointRequestResponse response)
+        => async context =>
+        {
+            context.Response.StatusCode = response.StatusCode;
+            await Task.CompletedTask; // Simulate async operation for now
+        };
 }

--- a/EndpointManager.Abstractions/Models/AddEndpointRequest.cs
+++ b/EndpointManager.Abstractions/Models/AddEndpointRequest.cs
@@ -1,4 +1,11 @@
 namespace EndpointManager.Abstractions.Models;
 
 [Serializable]
-public record AddEndpointRequest(string Route, string Method, int Priority = 0);
+public record AddEndpointRequest(
+    string Route,
+    string Method,
+    EndpointRequestResponse? Response,
+    int Priority = 0);
+
+[Serializable]
+public record EndpointRequestResponse(int StatusCode);


### PR DESCRIPTION
* Add `EndpointRequestResponse`to allow setting a status code for the response.
* Update `AddEndpointRequest` to accept a nullable `EndpointRequestResponse`.
* Update `EndpointForgeDataSource.AddEndpoint to handle creating a response with the provided status code.
* Add tests for the above and refactor test names to be more human-readable.