### PR TITLE
Add Logging to `EndpointForgeManager`

### DIFF
--- a/EndpointForge.WebApi/Deserializers/RequestDeserializer.cs
+++ b/EndpointForge.WebApi/Deserializers/RequestDeserializer.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using EndpointForge.WebApi.Models;
 using EndpointManager.Abstractions.Models;
@@ -14,21 +15,17 @@ public static class RequestDeserializer
         try
         {
             var addEndpointRequest = await request.ReadFromJsonAsync<T>();
-            return new DeserializeResult<T>(addEndpointRequest);
+            return new DeserializeResult<T>(Result: addEndpointRequest);
         }
         catch (JsonException)
         {
-            return new DeserializeResult<T>
-            {
-                ErrorResult = TypedResults.UnprocessableEntity(new ErrorResponse([InvalidRequestBodyMessage]))
-            };
+            return new DeserializeResult<T>(
+                ErrorResponse: new ErrorResponse(HttpStatusCode.UnprocessableEntity, [InvalidRequestBodyMessage]));
         }
         catch
         {
-            return new DeserializeResult<T>
-            {
-                ErrorResult = TypedResults.BadRequest(new ErrorResponse([EmptyRequestBodyMessage]))
-            };
+            return new DeserializeResult<T>(
+                ErrorResponse: new ErrorResponse(HttpStatusCode.BadRequest, [EmptyRequestBodyMessage]));
         }
     }
 }

--- a/EndpointForge.WebApi/Extensions/ErrorResultExtensions.cs
+++ b/EndpointForge.WebApi/Extensions/ErrorResultExtensions.cs
@@ -1,0 +1,15 @@
+using System.Net;
+using EndpointManager.Abstractions.Models;
+
+namespace EndpointForge.WebApi.Extensions;
+
+public static class ErrorResultExtensions
+{
+    public static IResult GetTypedResult(this ErrorResponse errorResponse)
+        => errorResponse.StatusCode switch
+        {
+            HttpStatusCode.UnprocessableEntity => TypedResults.UnprocessableEntity(errorResponse),
+            HttpStatusCode.Conflict => TypedResults.Conflict(errorResponse),
+            _ => TypedResults.BadRequest(errorResponse)
+        };
+}

--- a/EndpointForge.WebApi/Extensions/LoggerExtensions.cs
+++ b/EndpointForge.WebApi/Extensions/LoggerExtensions.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using EndpointManager.Abstractions.Models;
+
+namespace EndpointForge.WebApi.Extensions;
+
+internal static partial class LoggerExtensions
+{
+    #region Error Response
+
+    [LoggerMessage(LogLevel.Debug, "{ErrorResponse}")]
+    private static partial void ErrorResponse(
+        this ILogger logger,
+        [LogProperties(OmitReferenceName = true)]
+        in ErrorResponse errorResponse);
+
+    [LoggerMessage(LogLevel.Information, "An Error Response has been returned: [{statusCode}] {statusDescription}")]
+    public static partial void ErrorResponseInformation(
+        this ILogger logger,
+        int statusCode,
+        HttpStatusCode statusDescription);
+
+    public static void LogErrorResponse(this ILogger logger, ErrorResponse errorResponse)
+    {
+        logger.ErrorResponseInformation((int)errorResponse.StatusCode, errorResponse.StatusCode);
+        logger.ErrorResponse(errorResponse);
+    }
+
+    #endregion
+
+    [LoggerMessage(LogLevel.Debug, "{AddEndpointRequest}")]
+    private static partial void AddEndpointRequest(
+        this ILogger logger,
+        [LogProperties(OmitReferenceName = true)] in AddEndpointRequest addEndpointRequest);
+
+    [LoggerMessage(LogLevel.Information, "Endpoint Created: {Details}")]
+    private static partial void EndpointRoutingDetails(
+        this ILogger logger,
+        [LogProperties(OmitReferenceName = true)] in EndpointRoutingDetails details);
+
+    public static void LogAddEndpointRequestCompleted(this ILogger logger, AddEndpointRequest addEndpointRequest)
+    {
+        foreach (var details in addEndpointRequest.EndpointRoutingDetails)
+        {
+            logger.EndpointRoutingDetails(details); 
+        }
+        logger.AddEndpointRequest(addEndpointRequest);
+    }
+}

--- a/EndpointForge.WebApi/Models/DeserializeResult.cs
+++ b/EndpointForge.WebApi/Models/DeserializeResult.cs
@@ -1,3 +1,5 @@
+using EndpointManager.Abstractions.Models;
+
 namespace EndpointForge.WebApi.Models;
 
-public record DeserializeResult<T>(T? Result = null, IResult? ErrorResult = null) where T : class;
+public record DeserializeResult<T>(T? Result = null, ErrorResponse? ErrorResponse = null) where T : class;

--- a/EndpointForge.WebApi/Program.cs
+++ b/EndpointForge.WebApi/Program.cs
@@ -1,8 +1,16 @@
+using System.Text.Json.Serialization;
 using EndpointForge.WebApi.Extensions;
 using EndpointManager.Abstractions.Interfaces;
 using EndpointManager.Abstractions.Models;
+using Microsoft.AspNetCore.Http.Json;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.Configure<JsonOptions>(options =>
+{
+    options.SerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+});
+
 builder.Services.AddEndpointForge();
 builder.Services.AddOpenApi();
 builder.AddServiceDefaults();

--- a/EndpointManager.Abstractions/Models/ErrorResponse.cs
+++ b/EndpointManager.Abstractions/Models/ErrorResponse.cs
@@ -1,3 +1,8 @@
+using System.Net;
+
 namespace EndpointManager.Abstractions.Models;
 
-public record ErrorResponse(IEnumerable<string> Errors);
+public record ErrorResponse(HttpStatusCode StatusCode, IEnumerable<string> Errors)
+{ 
+    public override string ToString() => $"StatusCode={StatusCode}, Errors=[{string.Join(", ", Errors)}]";
+}


### PR DESCRIPTION
* Reformat `AddEndpointTests` for readability.
* Refactor DeserializeResult to return an `ErrorResponse` instead of an IResult, to enable correct logging.
* Add `ToString()` override for ErrorResponse to correctly display `Errors` when logging.
* Add extension `GetTypedResult` for `ErrorResponse` to generate a `TypedResult` from the errors and status code.
* Add serializer option to ignore nulls when writing serializing JSON.
* Add LoggerExtensions for `Created` and `Errored` responses to ensure efficient structured logs are produced.
* Add logging structured `Information` messages and explicit `Debug` messages to ensure visibility both when consuming structured logs and console logs.