### PR TITLE
Fix equality issue in `AddEndpointRequest`

### DIFF
--- a/EndpointForge.Abstractions/Models/AddEndpointRequest.cs
+++ b/EndpointForge.Abstractions/Models/AddEndpointRequest.cs
@@ -4,7 +4,7 @@ namespace EndpointForge.Abstractions.Models;
 public record AddEndpointRequest
 {
     public required string Route { get; init; }
-    public required string[] Methods { get; init; } = [];
+    public required List<string> Methods { get; init; } = [];
     public EndpointResponseDetails Response { get; init; } = new();
     public int Priority { get; init; }
     

--- a/EndpointForge.WebApi/Managers/EndpointForgeManager.cs
+++ b/EndpointForge.WebApi/Managers/EndpointForgeManager.cs
@@ -54,7 +54,7 @@ public class EndpointForgeManager(
         
         if (string.IsNullOrWhiteSpace(addEndpointRequest.Route))
             errors.Add(RouteMissingOrEmptyMessage);
-        if (addEndpointRequest.Methods.Length == 0)
+        if (addEndpointRequest.Methods.Count == 0)
             errors.Add(MethodMissingOrEmptyMessage);
 
         if (errors.Count is 0)


### PR DESCRIPTION
* Change `Methods` in `AddEndpointRequest` from a string array to a list as this implements IEquatable.
* Change length check on `Method` to use `Count` instead now that a list is being used.