### PR TITLE
Improve Allocations for `AddEndpointRequest`

### DIFF
--- a/EndpointForge.Abstractions/Exceptions/BadRequestEndpointForgeException.cs
+++ b/EndpointForge.Abstractions/Exceptions/BadRequestEndpointForgeException.cs
@@ -4,5 +4,5 @@ namespace EndpointForge.Abstractions.Exceptions;
 
 public class BadRequestEndpointForgeException(IEnumerable<string>? errors) : EndpointForgeException(
     HttpStatusCode.BadRequest, 
-    "Request body was of an unknown type or is missing required fields.",
+    "Request body was of an unknown type, empty, or is missing required fields.",
     errors);

--- a/EndpointForge.Abstractions/Models/AddEndpointRequest.cs
+++ b/EndpointForge.Abstractions/Models/AddEndpointRequest.cs
@@ -5,9 +5,9 @@ namespace EndpointForge.Abstractions.Models;
 public record AddEndpointRequest
 {
     public required string Route { get; init; } = string.Empty;
-    public required ImmutableList<string> Methods { get; init; } = [];
+    public required List<string> Methods { get; init; } = [];
     public EndpointResponseDetails Response { get; init; } = new();
-    public ImmutableList<EndpointForgeParameterDetails> Parameters { get; init; } = [];
+    public List<EndpointForgeParameterDetails> Parameters { get; init; } = [];
     
     public IEnumerable<EndpointRoutingDetails> GetEndpointRoutingDetails() => 
         Methods.Select(method => new EndpointRoutingDetails(Route, method));

--- a/EndpointForge.Abstractions/Models/EndpointResponseDetails.cs
+++ b/EndpointForge.Abstractions/Models/EndpointResponseDetails.cs
@@ -1,8 +1,8 @@
 namespace EndpointForge.Abstractions.Models;
 
-public record EndpointResponseDetails
+public class EndpointResponseDetails
 {
-    public int StatusCode { get; init; } = 200;
-    public string? ContentType { get; init; }
-    public string? Body {get; init; }
+    public int StatusCode { get; set; } = 200;
+    public string? ContentType { get; set; }
+    public string? Body {get; set; }
 }

--- a/EndpointForge.Abstractions/Models/EndpointResponseDetails.cs
+++ b/EndpointForge.Abstractions/Models/EndpointResponseDetails.cs
@@ -4,5 +4,5 @@ public record EndpointResponseDetails
 {
     public int StatusCode { get; init; } = 200;
     public string? ContentType { get; init; }
-    public string? Body {get; init;}
+    public string? Body {get; init; }
 }

--- a/EndpointForge.AppHost/Properties/launchSettings.json
+++ b/EndpointForge.AppHost/Properties/launchSettings.json
@@ -16,7 +16,7 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
       "applicationUrl": "http://localhost:15222",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",

--- a/EndpointForge.IntegrationTests/EndpointTests/AddEndpointTests.cs
+++ b/EndpointForge.IntegrationTests/EndpointTests/AddEndpointTests.cs
@@ -17,7 +17,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
         var expectedResponseBody = new
         {
             StatusCode = HttpStatusCode.BadRequest,
-            Message = "Request body is empty or of an unsupported type."
+            Message = "Request body was of an unknown type, empty, or is missing required fields."
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
 
@@ -42,11 +42,11 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
         var expectedResponseBody = new
         {
             StatusCode = HttpStatusCode.BadRequest,
-            Message = "Request body was of an unknown type or is missing required fields.",
+            Message = "Request body was of an unknown type, empty, or is missing required fields.",
             Errors = new []
             {
                 "JSON deserialization for type 'EndpointForge.Abstractions.Models.AddEndpointRequest' " +
-                "was missing required properties including: 'route'."
+                "was missing required properties including: 'Route'."
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
@@ -69,11 +69,11 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
         var expectedResponseBody = new
         {
             StatusCode = HttpStatusCode.BadRequest,
-            Message = "Request body was of an unknown type or is missing required fields.",
+            Message = "Request body was of an unknown type, empty, or is missing required fields.",
             Errors = new[]
             {
                 "JSON deserialization for type 'EndpointForge.Abstractions.Models.AddEndpointRequest' " +
-                "was missing required properties including: 'methods'."
+                "was missing required properties including: 'Methods'."
                 
             }
         };
@@ -191,12 +191,10 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
 
         var response = await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
-        var responseBody = await response.Content.ReadFromJsonAsync<AddEndpointRequest>();
-
+        
         Assert.Multiple(
             () => response.StatusCode.Should().Be(HttpStatusCode.Created),
-            () => response.Headers.Location.Should().Be(addEndpointRequest.Route),
-            () => responseBody.Should().BeEquivalentTo(addEndpointRequest));
+            () => response.Headers.Location.Should().Be(addEndpointRequest.Route));
     }
 
     #endregion

--- a/EndpointForge.WebApi.Tests/DataSources/EndpointForgeDataSourceTests.cs
+++ b/EndpointForge.WebApi.Tests/DataSources/EndpointForgeDataSourceTests.cs
@@ -43,10 +43,7 @@ public class EndpointForgeDataSourceTests
         {
             Route = "/test/route",
             Methods = ["GET"],
-            Parameters = new List<EndpointForgeParameterDetails>
-            {
-                new("test-parameter", "test-parameter-value")
-            }.ToImmutableList()
+            Parameters = [new EndpointForgeParameterDetails("test-parameter", "test-parameter-value")]
         };
         var stubResponseBodyParser = new FakeResponseBodyParser(string.Empty);
 

--- a/EndpointForge.WebApi.Tests/Extensions/HttpRequestExtensionsTests.cs
+++ b/EndpointForge.WebApi.Tests/Extensions/HttpRequestExtensionsTests.cs
@@ -47,7 +47,9 @@ public class HttpRequestExtensionsTests
 
         Assert.Multiple(
             () => exception.StatusCode.Should().Be(HttpStatusCode.BadRequest),
-            () => exception.Message.Should().Be("Request body was of an unknown type or is missing required fields."));
+            () => exception.Message
+                .Should()
+                .Be("Request body was of an unknown type, empty, or is missing required fields."));
     }
 
     [Fact]
@@ -55,8 +57,14 @@ public class HttpRequestExtensionsTests
     {
         var httpContext = new DefaultHttpContext();
 
-        await Assert.ThrowsAsync<EmptyRequestBodyEndpointForgeException>(
+        var exception = await Assert.ThrowsAsync<BadRequestEndpointForgeException>(
             async () => await httpContext.Request.TryDeserializeRequestAsync<AddEndpointRequest>());
+        
+        Assert.Multiple(
+            () => exception.StatusCode.Should().Be(HttpStatusCode.BadRequest),
+            () => exception.Message
+                .Should()
+                .Be("Request body was of an unknown type, empty, or is missing required fields."));
     }
 
     #endregion

--- a/EndpointForge.WebApi.Tests/Managers/EndpointForgeManagerTests.cs
+++ b/EndpointForge.WebApi.Tests/Managers/EndpointForgeManagerTests.cs
@@ -38,8 +38,9 @@ public class EndpointForgeManagerTests
 
         var result = await _endpointForgeManager.TryAddEndpointAsync(addEndpointRequest);
 
-        _stubEndpointForgeDataSource.AddedEndpoints.Should().ContainSingle(e => e == addEndpointRequest);
-        result.Should().BeOfType<Created<AddEndpointRequest>>();
+        Assert.Multiple(
+            () => _stubEndpointForgeDataSource.AddedEndpoints.Should().ContainSingle(e => e == addEndpointRequest),
+            () => result.Should().BeOfType<Created>());
     }
 
     [Fact]

--- a/EndpointForge.WebApi.Tests/Middleware/ExceptionHandlingMiddlewareTests.cs
+++ b/EndpointForge.WebApi.Tests/Middleware/ExceptionHandlingMiddlewareTests.cs
@@ -49,7 +49,7 @@ public class ExceptionHandlingMiddlewareTests
     public async Task When_UnhandledExceptionIsThrown_Expect_ResponseWithBadRequestAndGenericMessage()
     {
         const string errorMessage = "test-exception-message";
-        const string exceptionMessage = "Request body was of an unknown type or is missing required fields.";
+        const string exceptionMessage = "Request body was of an unknown type, empty, or is missing required fields.";
         var unhandledException = new Exception("test-exception-message");
         var expectedErrorResponse = new ErrorResponse(HttpStatusCode.BadRequest, exceptionMessage, [errorMessage]);
 

--- a/EndpointForge.WebApi/DataSources/EndpointForgeDataSource.cs
+++ b/EndpointForge.WebApi/DataSources/EndpointForgeDataSource.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net.Mime;
 using EndpointForge.Abstractions.Extensions;
 using EndpointForge.Abstractions.Interfaces;
@@ -14,8 +15,13 @@ public class EndpointForgeDataSource(
 {
     public void AddEndpoint(AddEndpointRequest addEndpointRequest, bool apply = true)
     {
-        var parameters = addEndpointRequest.Parameters.ToDictionary(p => p.Identifier, p => p.Value);
-        
+        var parameters = new Dictionary<string, string>(addEndpointRequest.Parameters.Count);
+        foreach (var parameter in addEndpointRequest.Parameters)
+        {
+            parameters[parameter.Identifier] = parameter.Value;
+        }
+
+        // Create the endpoint
         var endpoint = new RouteEndpointBuilder(
                 BuildResponse(addEndpointRequest.Response, parameters),
                 RoutePatternFactory.Parse(addEndpointRequest.Route),
@@ -24,6 +30,8 @@ public class EndpointForgeDataSource(
                 Metadata = { new HttpMethodMetadata(addEndpointRequest.Methods) }
             }
             .Build();
+
+        // Add endpoint to the data source
         base.AddEndpoint(endpoint, apply);
     }
 

--- a/EndpointForge.WebApi/Extensions/HttpRequestExtensions.cs
+++ b/EndpointForge.WebApi/Extensions/HttpRequestExtensions.cs
@@ -26,13 +26,9 @@ public static class HttpRequestExtensions
              var result = JsonSerializer.Deserialize<T>(ref reader, Options);
              return result ?? throw new InvalidRequestBodyEndpointForgeException();
          }
-         catch (JsonException exception)
+         catch (Exception exception)
          {
              throw new BadRequestEndpointForgeException([exception.Message]);
-         }
-         catch
-         {
-             throw new EmptyRequestBodyEndpointForgeException();
          }
     }
 }

--- a/EndpointForge.WebApi/Managers/EndpointForgeManager.cs
+++ b/EndpointForge.WebApi/Managers/EndpointForgeManager.cs
@@ -25,7 +25,7 @@ public class EndpointForgeManager(
         logger.LogAddEndpointRequestCompleted(addEndpointRequest);
         
         await Task.CompletedTask;
-        return TypedResults.Created(addEndpointRequest.Route, addEndpointRequest);
+        return TypedResults.Created(addEndpointRequest.Route);
     }
 
     private void ValidateEndpointRequestOrThrow(AddEndpointRequest addEndpointRequest) 


### PR DESCRIPTION
* Refactor to for fewer allocations by manually controlling the buffer stream when deserializing.