### PR TITLE
Capture headers as Parameters

### DIFF
--- a/EndpointForge.Abstractions.Tests/Extensions/EndpointResponseDetailsExtensionsTests.cs
+++ b/EndpointForge.Abstractions.Tests/Extensions/EndpointResponseDetailsExtensionsTests.cs
@@ -21,11 +21,11 @@ public class EndpointResponseDetailsExtensionsTests
     [Theory]
     [StringNullEmptyOrWhitespaceInlineData]
     [InlineData("text/test-type", true)]
-    public void When_HasContentTypeIsCalled(string? body, bool expectedResult)
+    public void When_HasContentTypeIsCalled(string? contentType, bool expectedResult)
     {
-        EndpointResponseDetails endpointResponseDetails = new() { Body = body };
+        EndpointResponseDetails endpointResponseDetails = new() { ContentType = contentType };
 
-        var result = endpointResponseDetails.HasBody();
+        var result = endpointResponseDetails.HasContentType();
 
         result.Should().Be(expectedResult);
     }

--- a/EndpointForge.Abstractions/Exceptions/EmptyRequestBodyEndpointForgeException.cs
+++ b/EndpointForge.Abstractions/Exceptions/EmptyRequestBodyEndpointForgeException.cs
@@ -1,7 +1,0 @@
-using System.Net;
-
-namespace EndpointForge.Abstractions.Exceptions;
-
-public class EmptyRequestBodyEndpointForgeException() : EndpointForgeException(
-    HttpStatusCode.BadRequest, 
-    "Request body is empty or of an unsupported type.");

--- a/EndpointForge.Abstractions/Interfaces/IParameterProcessor.cs
+++ b/EndpointForge.Abstractions/Interfaces/IParameterProcessor.cs
@@ -1,0 +1,9 @@
+using EndpointForge.Abstractions.Models;
+using Microsoft.AspNetCore.Http;
+
+namespace EndpointForge.Abstractions.Interfaces;
+
+public interface IParameterProcessor
+{
+    Dictionary<string, string> Process(List<EndpointForgeParameterDetails> parameters, HttpContext context);
+}

--- a/EndpointForge.Abstractions/Interfaces/IRequestDelegateBuilder.cs
+++ b/EndpointForge.Abstractions/Interfaces/IRequestDelegateBuilder.cs
@@ -1,0 +1,11 @@
+using EndpointForge.Abstractions.Models;
+using Microsoft.AspNetCore.Http;
+
+namespace EndpointForge.Abstractions.Interfaces;
+
+public interface IRequestDelegateBuilder
+{
+    RequestDelegate BuildResponse(
+        EndpointResponseDetails responseDetails, 
+        List<EndpointForgeParameterDetails> parameters);
+}

--- a/EndpointForge.Abstractions/Interfaces/IResponseBodyParser.cs
+++ b/EndpointForge.Abstractions/Interfaces/IResponseBodyParser.cs
@@ -4,5 +4,5 @@ namespace EndpointForge.Abstractions.Interfaces;
 
 public interface IResponseBodyParser
 {
-    Task ProcessResponseBody(Stream stream, string responseBody, List<EndpointForgeParameterDetails> parameters);
+    Task ProcessResponseBody(Stream stream, string responseBody, Dictionary<string, string> parameters);
 }

--- a/EndpointForge.Abstractions/Models/EndpointResponseDetails.cs
+++ b/EndpointForge.Abstractions/Models/EndpointResponseDetails.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace EndpointForge.Abstractions.Models;
 
 public class EndpointResponseDetails
@@ -5,4 +7,7 @@ public class EndpointResponseDetails
     public int StatusCode { get; set; } = 200;
     public string? ContentType { get; set; }
     public string? Body {get; set; }
+
+    [ExcludeFromCodeCoverage]
+    public override string ToString() => $"StatusCode: {StatusCode}, ContentType: {ContentType}, Body: {Body}";
 }

--- a/EndpointForge.IntegrationTests/EndpointTests/AddEndpointTests.cs
+++ b/EndpointForge.IntegrationTests/EndpointTests/AddEndpointTests.cs
@@ -438,5 +438,44 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
         
          responseBody.Should().Be("test-value");
     }
+    
+        
+    [Fact]
+    public async Task When_ProvidingHeaderParameter_Expect_EndpointResponseBodyToContainThatHeaderValue()
+    {
+        const string headerValue = "test-header-value";
+        var addEndpointRequest = new
+        {
+            Route = "/test-endpoint-with-header-value",
+            Methods = new[]
+            {
+                "GET"
+            },
+            Response = new
+            {
+                StatusCode = 201,
+                ContentType = "text/test-type",
+                Body = "{{insert:parameter:test-header-parameter}}"
+            },
+            Parameters = new[]
+            {
+                new
+                {
+                    Type = "header",
+                    Identifier = "XCustom-Header",
+                    Value = "test-header-parameter"
+                    
+                }
+            }
+        };
+        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        httpClient.DefaultRequestHeaders.Add("XCustom-Header", headerValue);
+
+        await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        var response = await httpClient.GetAsync(addEndpointRequest.Route);
+        var responseBody = await response.Content.ReadAsStringAsync();
+        
+        responseBody.Should().Be("test-header-value");
+    }
     #endregion
 }

--- a/EndpointForge.WebApi.Tests/Builders/RequestDelegateBuilderTests.cs
+++ b/EndpointForge.WebApi.Tests/Builders/RequestDelegateBuilderTests.cs
@@ -1,0 +1,170 @@
+using EndpointForge.Abstractions.Interfaces;
+using EndpointForge.Abstractions.Models;
+using EndpointForge.WebApi.Builders;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.IO;
+using Moq;
+
+namespace EndpointForge.WebApi.Tests.Builders;
+
+public class RequestDelegateBuilderTests
+{
+    private readonly RecyclableMemoryStreamManager _recyclableMemoryStreamManager = new();
+    private readonly Mock<IResponseBodyParser> _mockResponseBodyParser = new();
+    private readonly Mock<IParameterProcessor> _stubParameterProcessor = new();
+    private readonly HttpContext _httpContext;
+    private readonly RequestDelegateBuilder _requestDelegateBuilder;
+
+    public RequestDelegateBuilderTests()
+    {
+        _requestDelegateBuilder = new RequestDelegateBuilder(
+            NullLogger,
+            _mockResponseBodyParser.Object,
+            _stubParameterProcessor.Object,
+            _recyclableMemoryStreamManager);
+        _httpContext = new DefaultHttpContext
+        {
+            Response = { Body = new MemoryStream() }
+        };
+    }
+    
+    private static readonly ILogger<RequestDelegateBuilder> NullLogger = new NullLogger<RequestDelegateBuilder>();
+    
+    [Fact]
+    public async Task When_BuildResponse_Expect_ContextResponseHasStatusCodeSet()
+    {
+        var endpointResponseDetails = new EndpointResponseDetails
+        {
+            StatusCode = 201
+        };
+        
+        var responseDelegate = _requestDelegateBuilder.BuildResponse(endpointResponseDetails, []);
+        await responseDelegate.Invoke(_httpContext);
+        
+        _httpContext.Response.StatusCode.Should().Be(201);
+    }
+    
+    [Fact]
+    public async Task When_BuildResponseHasNoBody_Expect_ContextResponseHasNoContentTypeSet()
+    {
+        var endpointResponseDetails = new EndpointResponseDetails
+        {
+            StatusCode = 201
+        };
+        
+        var responseDelegate = _requestDelegateBuilder.BuildResponse(endpointResponseDetails, []);
+        await responseDelegate.Invoke(_httpContext);
+
+        _httpContext.Response.ContentType.Should().BeNull();
+    }
+    
+    [Fact]
+    public async Task When_BuildResponseHasBodyAndNoContentType_Expect_ContextResponseIsPlainText()
+    {
+        var endpointResponseDetails = new EndpointResponseDetails
+        {
+            StatusCode = 201,
+            Body = "test-body"
+        };
+       
+        var responseDelegate = _requestDelegateBuilder.BuildResponse(endpointResponseDetails, []);
+        await responseDelegate.Invoke(_httpContext);
+
+        _httpContext.Response.ContentType.Should().Be("text/plain");
+    }
+    
+    [Fact]
+    public async Task When_BuildResponseHasBodyAndContentType_Expect_ContextResponseIsSetToContentType()
+    {
+        var endpointResponseDetails = new EndpointResponseDetails
+        {
+            StatusCode = 201,
+            Body = "test-body",
+            ContentType = "application/json"
+        };
+        var httpContext = new DefaultHttpContext();
+
+        var responseDelegate = _requestDelegateBuilder.BuildResponse(endpointResponseDetails, []);
+        await responseDelegate.Invoke(httpContext);
+
+        httpContext.Response.ContentType.Should().Be("application/json");
+    }
+
+    [Fact]
+    public async Task When_BuildResponseHasBody_Expect_ContextResponseBodyIsTestBody()
+    {
+        var endpointResponseDetails = new EndpointResponseDetails
+        {
+            StatusCode = 201,
+            Body = "test-body",
+            ContentType = "application/json"
+        };
+        _mockResponseBodyParser
+            .Setup(parser => parser.ProcessResponseBody(
+                It.IsAny<Stream>(), 
+                It.IsAny<string>(), 
+                It.IsAny<Dictionary<string, string>>()))
+            .Returns(async (Stream stream, string _, Dictionary<string, string> _) =>
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+                await using var writer = new StreamWriter(stream, leaveOpen: true);
+                await writer.WriteAsync("test-body");
+                await writer.FlushAsync();
+            });
+        
+        var responseDelegate = _requestDelegateBuilder.BuildResponse(endpointResponseDetails, []);
+        await responseDelegate.Invoke(_httpContext);
+
+        _httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(_httpContext.Response.Body);
+        var body = await reader.ReadToEndAsync();
+
+        Assert.Multiple(
+            () => body.Should().Be("test-body"),
+            () => _httpContext.Response.ContentLength.Should().Be(9));
+    }
+    
+    [Fact]
+    public async Task When_BuildResponseHasBody_Expect_ParserIsCalledWithProcessedParameters()
+    {
+        var endpointResponseDetails = new EndpointResponseDetails
+        {
+            StatusCode = 201,
+            Body = "test-body",
+            ContentType = "application/json",
+        };
+        var parameters = new List<EndpointForgeParameterDetails>
+        {
+            new("static", "test-parameter", "test-parameter-value"),
+        };
+        var expectedParameterDictionary = new Dictionary<string, string>()
+        {
+            { "test-parameter", "test-parameter-value" }
+        };
+        _mockResponseBodyParser
+            .Setup(parser => parser.ProcessResponseBody(
+                It.IsAny<Stream>(), 
+                It.IsAny<string>(), 
+                expectedParameterDictionary))
+            .Returns(async (Stream stream, string _, Dictionary<string, string> _) =>
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+                await using var writer = new StreamWriter(stream, leaveOpen: true);
+                await writer.WriteAsync("test-body");
+                await writer.FlushAsync();
+            });
+        _stubParameterProcessor
+            .Setup(processor => processor.Process(parameters, It.IsAny<HttpContext>()))
+            .Returns(expectedParameterDictionary);
+        
+        var responseDelegate = _requestDelegateBuilder.BuildResponse(endpointResponseDetails, parameters);
+        await responseDelegate.Invoke(_httpContext);
+        
+        _mockResponseBodyParser.Verify(parser => 
+            parser.ProcessResponseBody(It.IsAny<Stream>(), It.IsAny<string>(), expectedParameterDictionary),
+            Times.Once);
+    }
+}

--- a/EndpointForge.WebApi.Tests/DataSources/EndpointForgeDataSourceTests.cs
+++ b/EndpointForge.WebApi.Tests/DataSources/EndpointForgeDataSourceTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using EndpointForge.Abstractions.Interfaces;
 using EndpointForge.Abstractions.Models;
 using EndpointForge.WebApi.DataSources;
 using EndpointForge.WebApi.Tests.Fakes;
@@ -13,50 +14,26 @@ namespace EndpointForge.WebApi.Tests.DataSources;
 
 public class EndpointForgeDataSourceTests
 {
-    private readonly RecyclableMemoryStreamManager _memoryStreamManager = new();
     private readonly ILogger<EndpointForgeDataSource> _stubLogger = new NullLogger<EndpointForgeDataSource>();
+    private readonly FakeRequestDelegateBuilder _stubRequestDelegateBuilder = new();
 
+    
     [Fact]
-    public void When_AddEndpoint__AddEndpointWithCorrectRoute()
+    public void When_AddEndpointWithValidRoute_Expect_EndpointsContainsEndpointWithThatRoute()
     {
         var addEndpointRequest = new AddEndpointRequest
         {
             Route = "/test/route",
             Methods = ["GET"]
         };
-        var stubResponseBodyParser = new FakeResponseBodyParser(string.Empty);
 
-        var endpointForgeDataSource = new EndpointForgeDataSource(
-            _stubLogger,
-            stubResponseBodyParser,
-            _memoryStreamManager);
+        var endpointForgeDataSource = new EndpointForgeDataSource(_stubLogger, _stubRequestDelegateBuilder);
         endpointForgeDataSource.AddEndpoint(addEndpointRequest);
 
         var endpoint = (RouteEndpoint) endpointForgeDataSource.Endpoints.Single();
         endpoint.RoutePattern.RawText.Should().Be(addEndpointRequest.Route);
     }
-
-    [Fact]
-    public void When_AddEndpointWithParameters_AddEndpointWithCorrectRoute()
-    {
-        var addEndpointRequest = new AddEndpointRequest
-        {
-            Route = "/test/route",
-            Methods = ["GET"],
-            Parameters = [new EndpointForgeParameterDetails("static","test-parameter", "test-parameter-value")]
-        };
-        var stubResponseBodyParser = new FakeResponseBodyParser(string.Empty);
-
-        var endpointForgeDataSource = new EndpointForgeDataSource(
-            _stubLogger,
-            stubResponseBodyParser,
-            _memoryStreamManager);
-        endpointForgeDataSource.AddEndpoint(addEndpointRequest);
-
-        var endpoint = (RouteEndpoint) endpointForgeDataSource.Endpoints.Single();
-        endpoint.RoutePattern.RawText.Should().Be(addEndpointRequest.Route);
-    }
-
+    
     [Fact]
     public void When_AddEndpoint_Expect_EndpointAddedWithCorrectMethods()
     {
@@ -65,136 +42,38 @@ public class EndpointForgeDataSourceTests
             Route = "/test/route",
             Methods = ["GET", "POST"]
         };
-        var stubResponseBodyParser = new FakeResponseBodyParser(string.Empty);
-
-        var endpointForgeDataSource = new EndpointForgeDataSource(
-            _stubLogger,
-            stubResponseBodyParser,
-            _memoryStreamManager);
+        
+        var endpointForgeDataSource = new EndpointForgeDataSource(_stubLogger, _stubRequestDelegateBuilder);
         endpointForgeDataSource.AddEndpoint(addEndpointRequest);
-
+    
         var methodMetadata = endpointForgeDataSource
             .Endpoints.Single()
             .Metadata.GetMetadata<HttpMethodMetadata>();
-
+    
         methodMetadata?.HttpMethods
             .Should().NotBeNull()
             .And
             .BeEquivalentTo(addEndpointRequest.Methods);
     }
-
+    
     [Fact]
-    public async Task When_AddEndpointWithBodyAndContentType_Expect_EndpointResponseContentTypeIsTestTextAndHasBody()
+    public void When_AddEndpoint_Expect_ResponseBodyParserCalled()
     {
-        var httpContext = new DefaultHttpContext
-        {
-            Response = { Body = new MemoryStream() }
-        };
-
         var addEndpointRequest = new AddEndpointRequest
         {
             Route = "/test/route",
             Methods = ["GET", "POST"],
             Response = new EndpointResponseDetails
             {
-                StatusCode = 200,
-                ContentType = "text/test-text",
+                StatusCode = 0,
+                ContentType = "application/json",
                 Body = "Body"
             }
         };
-        var stubResponseBodyParser = new FakeResponseBodyParser("Body");
-
-        var endpointForgeDataSource = new EndpointForgeDataSource(
-            _stubLogger,
-            stubResponseBodyParser,
-            _memoryStreamManager);
+        var mockRequestDelegateBuilder = new FakeRequestDelegateBuilder();
+        var endpointForgeDataSource = new EndpointForgeDataSource(_stubLogger, mockRequestDelegateBuilder);
         endpointForgeDataSource.AddEndpoint(addEndpointRequest);
-
-        var responseBody = await ExtractResponseBody(endpointForgeDataSource, httpContext);
-        Assert.Multiple(
-            () => httpContext.Response.StatusCode.Should().Be(200),
-            () => httpContext.Response.ContentType.Should().Be("text/test-text"),
-            () => httpContext.Response.ContentLength.Should().Be(4),
-            () => responseBody.Should().Be("Body"));
-    }
-
-    [Fact]
-    public async Task When_AddEndpointWithBodyAndNoContentType_Expect_EndpointResponseContentTypeIsTextPlainAndBody()
-    {
-        var httpContext = new DefaultHttpContext
-        {
-            Response = { Body = new MemoryStream() }
-        };
-
-        var addEndpointRequest = new AddEndpointRequest
-        {
-            Route = "/test/route",
-            Methods = ["GET"],
-            Response = new EndpointResponseDetails
-            {
-                StatusCode = 200,
-                Body = "Body"
-            }
-        };
-        var stubResponseBodyParser = new FakeResponseBodyParser("Body");
-
-        var endpointForgeDataSource = new EndpointForgeDataSource(
-            _stubLogger,
-            stubResponseBodyParser,
-            _memoryStreamManager);
-        endpointForgeDataSource.AddEndpoint(addEndpointRequest);
-
-        var responseBody = await ExtractResponseBody(endpointForgeDataSource, httpContext);
-        Assert.Multiple(
-            () => httpContext.Response.StatusCode.Should().Be(200),
-            () => httpContext.Response.ContentType.Should().Be("text/plain"),
-            () => httpContext.Response.ContentLength.Should().Be(4),
-            () => responseBody.Should().Be("Body"));
-    }
-
-    [Fact]
-    public async Task When_AddEndpointWithNoBody_Expect_EndpointResponseContentTypeIsEmptyAndNoBody()
-    {
-        var httpContext = new DefaultHttpContext
-        {
-            Response = { Body = new MemoryStream() }
-        };
-
-        var addEndpointRequest = new AddEndpointRequest
-        {
-            Route = "/test/route",
-            Methods = ["GET"],
-            Response = new EndpointResponseDetails
-            {
-                StatusCode = 200,
-                ContentType = "text/plain"
-            }
-        };
-        var stubResponseBodyParser = new FakeResponseBodyParser(string.Empty);
-
-        var endpointForgeDataSource = new EndpointForgeDataSource(
-            _stubLogger,
-            stubResponseBodyParser,
-            _memoryStreamManager);
-
-        endpointForgeDataSource.AddEndpoint(addEndpointRequest);
-
-        var responseBody = await ExtractResponseBody(endpointForgeDataSource, httpContext);
-        Assert.Multiple(
-            () => httpContext.Response.StatusCode.Should().Be(200),
-            () => httpContext.Response.ContentType.Should().BeNull(),
-            () => httpContext.Response.ContentLength.Should().BeNull(),
-            () => responseBody.Should().BeEmpty());
-    }
-
-    private static async Task<string> ExtractResponseBody(
-        EndpointForgeDataSource endpointForgeDataSource,
-        DefaultHttpContext httpContext)
-    {
-        var requestDelegate = endpointForgeDataSource.Endpoints.Single().RequestDelegate!;
-        await requestDelegate(httpContext);
-
-        httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
-        return await new StreamReader(httpContext.Response.Body).ReadToEndAsync();
+        
+        mockRequestDelegateBuilder.HasBeenCalled.Should().BeTrue();
     }
 }

--- a/EndpointForge.WebApi.Tests/EndpointForge.WebApi.Tests.csproj
+++ b/EndpointForge.WebApi.Tests/EndpointForge.WebApi.Tests.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
         <PackageReference Include="FluentAssertions" Version="7.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
+        <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
     </ItemGroup>

--- a/EndpointForge.WebApi.Tests/Extensions/EndpointRouteBuilderExtensionsTests.cs
+++ b/EndpointForge.WebApi.Tests/Extensions/EndpointRouteBuilderExtensionsTests.cs
@@ -1,6 +1,7 @@
 using EndpointForge.Abstractions.Exceptions;
 using EndpointForge.WebApi.DataSources;
 using EndpointForge.WebApi.Extensions;
+using EndpointForge.WebApi.Tests.DataSources;
 using EndpointForge.WebApi.Tests.Fakes;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -15,11 +16,10 @@ public class EndpointRouteBuilderExtensionsTests
     [Fact]
     public void When_UseEndpointForgeAndDataSourceIsFound_Expect_DataSourceAddedToDataSources()
     {
-        var memoryStreamManager = new RecyclableMemoryStreamManager();
         var stubBuilder = new FakeEndpointRouteBuilder();
-        var stubResponseBodyParser = new FakeResponseBodyParser(string.Empty);
+        var stubRequestDelegateBuilder = new FakeRequestDelegateBuilder();
         var stubLogger = new NullLogger<EndpointForgeDataSource>();
-        var dataSource = new EndpointForgeDataSource(stubLogger, stubResponseBodyParser, memoryStreamManager);
+        var dataSource = new EndpointForgeDataSource(stubLogger, stubRequestDelegateBuilder);
         stubBuilder.ServiceProvider = new FakeServiceProvider(dataSource);
         
         stubBuilder.UseEndpointForge();

--- a/EndpointForge.WebApi.Tests/Fakes/FakeRequestDelegateBuilder.cs
+++ b/EndpointForge.WebApi.Tests/Fakes/FakeRequestDelegateBuilder.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics.CodeAnalysis;
+using EndpointForge.Abstractions.Interfaces;
+using EndpointForge.Abstractions.Models;
+using Microsoft.AspNetCore.Http;
+
+namespace EndpointForge.WebApi.Tests.Fakes;
+
+[ExcludeFromCodeCoverage]
+public class FakeRequestDelegateBuilder: IRequestDelegateBuilder
+{
+    public bool HasBeenCalled { get; private set; }
+
+    public RequestDelegate BuildResponse(
+        EndpointResponseDetails responseDetails,
+        List<EndpointForgeParameterDetails> parameters)
+    {
+        HasBeenCalled = true;
+        return async _ => { await Task.CompletedTask; };
+    }
+}

--- a/EndpointForge.WebApi.Tests/Fakes/FakeResponseBodyParser.cs
+++ b/EndpointForge.WebApi.Tests/Fakes/FakeResponseBodyParser.cs
@@ -1,20 +1,20 @@
 using System.Diagnostics.CodeAnalysis;
 using EndpointForge.Abstractions.Interfaces;
-using EndpointForge.Abstractions.Models;
 
-namespace EndpointForge.WebApi.Tests.Fakes;
-
-[ExcludeFromCodeCoverage]
-internal class FakeResponseBodyParser(string body) : IResponseBodyParser
+namespace EndpointForge.WebApi.Tests.Fakes
 {
-    public async Task ProcessResponseBody(
-        Stream stream, 
-        string responseBody, 
-        List<EndpointForgeParameterDetails> parameters)
+    [ExcludeFromCodeCoverage]
+    internal record FakeResponseBodyParser(string Body) : IResponseBodyParser
     {
-        stream.Seek(0, SeekOrigin.Begin);
-        var streamWriter = new StreamWriter(stream);
-        await streamWriter.WriteAsync(body);
-        await streamWriter.FlushAsync();
+        public async Task ProcessResponseBody(
+            Stream stream, 
+            string responseBody, 
+            Dictionary<string, string> parameters)
+        {
+            stream.Seek(0, SeekOrigin.Begin);
+            await using var streamWriter = new StreamWriter(stream, leaveOpen: true);
+            await streamWriter.WriteAsync(Body);
+            await streamWriter.FlushAsync();
+        }
     }
 }

--- a/EndpointForge.WebApi.Tests/Parsers/ResponseBodyParserTests.cs
+++ b/EndpointForge.WebApi.Tests/Parsers/ResponseBodyParserTests.cs
@@ -106,7 +106,9 @@ public class ResponseBodyParserTests
         await responseBodyParser.ProcessResponseBody(
             stream, 
             body, 
-            [new("static", "test-parameter", "parameter-value")]);
+            new Dictionary<string, string> {
+                { "test-parameter", "parameter-value" }
+            });
         
         stream.Seek(0, SeekOrigin.Begin);
         var responseBody = await new StreamReader(stream).ReadToEndAsync();
@@ -162,9 +164,9 @@ public class ResponseBodyParserTests
         var stubEndpointForgeRuleFactory = new FakeEndpointForgeRuleFactory(
             new FakeInsertRule("parameter"));
         var responseBodyParser = new ResponseBodyParser(StubLogger, stubEndpointForgeRuleFactory);
-        var parameters = new List<EndpointForgeParameterDetails>
+        var parameters = new Dictionary<string, string>
         {
-            new("static", "test-parameter", "parameter-value")
+            { "test-parameter", "parameter-value" }
         };
         var stream = new MemoryStream();
         
@@ -184,9 +186,9 @@ public class ResponseBodyParserTests
         var stubEndpointForgeRuleFactory = new FakeEndpointForgeRuleFactory(
             new FakeInsertRule("parameter"));
         var responseBodyParser = new ResponseBodyParser(StubLogger, stubEndpointForgeRuleFactory);
-        var parameters = new List<EndpointForgeParameterDetails>
+        var parameters = new Dictionary<string, string>
         {
-            new("static", "test-parameter", "parameter-value")
+            { "test-parameter", "parameter-value" }
         };
         var stream = new MemoryStream();
         
@@ -206,10 +208,10 @@ public class ResponseBodyParserTests
         var stubEndpointForgeRuleFactory = new FakeEndpointForgeRuleFactory(
             new FakeInsertRule("parameter"));
         var responseBodyParser = new ResponseBodyParser(StubLogger, stubEndpointForgeRuleFactory);
-        var parameters = new List<EndpointForgeParameterDetails>
+        var parameters = new Dictionary<string, string>
         {
-            new("static", "test-parameter-1", "parameter-value-1"),
-            new("static", "test-parameter-2", "parameter-value-2")
+            { "test-parameter-1", "parameter-value-1" },
+            { "test-parameter-2", "parameter-value-2" }
         };
         var stream = new MemoryStream();
         
@@ -229,9 +231,9 @@ public class ResponseBodyParserTests
         var stubEndpointForgeRuleFactory = new FakeEndpointForgeRuleFactory(
             new FakeInsertRule("parameter"));
         var responseBodyParser = new ResponseBodyParser(StubLogger, stubEndpointForgeRuleFactory);
-        var parameters = new List<EndpointForgeParameterDetails>
+        var parameters = new Dictionary<string, string>
         {
-            new("static", "test-parameter-2", "parameter-value-2")
+            { "test-parameter-2", "parameter-value-2" }
         };
         var stream = new MemoryStream();
         

--- a/EndpointForge.WebApi.Tests/Processors/ParameterProcessorTests.cs
+++ b/EndpointForge.WebApi.Tests/Processors/ParameterProcessorTests.cs
@@ -1,0 +1,47 @@
+using EndpointForge.Abstractions.Models;
+using EndpointForge.WebApi.Processors;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+
+namespace EndpointForge.WebApi.Tests.Processors;
+
+public class ParameterProcessorTests
+{
+    [Fact]
+    public void When_ProcessWithStaticParameter_Expect_ParameterMappedInDictionary()
+    {
+        var parameters = new List<EndpointForgeParameterDetails>
+        {
+            new("static", "identifier", "parameter-value")
+        };
+        var expectedParameterDictionary = new Dictionary<string, object>
+        {
+            { "identifier", "parameter-value" }
+        };
+        var parameterProcessor = new ParameterProcessor();
+        var httpContext = new DefaultHttpContext();
+        var processedParameterDictionary = parameterProcessor.Process(parameters, httpContext);
+        
+        processedParameterDictionary.Should().BeEquivalentTo(expectedParameterDictionary);
+    }
+    
+    [Fact]
+    public void When_ProcessWithHeaderParameter_Expect_ParameterMappedFromHeadersInToDictionary()
+    {
+        var parameters = new List<EndpointForgeParameterDetails>
+        {
+            new("header", "XCustom-Header", "parameterName")
+        };
+        var expectedParameterDictionary = new Dictionary<string, object>
+        {
+            { "parameterName", "parameter-value" }
+        };
+        var parameterProcessor = new ParameterProcessor();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.Append("XCustom-Header", "parameter-value");
+        
+        var processedParameterDictionary = parameterProcessor.Process(parameters, httpContext);
+        
+        processedParameterDictionary.Should().BeEquivalentTo(expectedParameterDictionary);
+    }
+}

--- a/EndpointForge.WebApi/Builders/RequestDelegateBuilder.cs
+++ b/EndpointForge.WebApi/Builders/RequestDelegateBuilder.cs
@@ -1,0 +1,49 @@
+using System.Net.Mime;
+using EndpointForge.Abstractions.Extensions;
+using EndpointForge.Abstractions.Interfaces;
+using EndpointForge.Abstractions.Models;
+using Microsoft.IO;
+
+namespace EndpointForge.WebApi.Builders;
+
+public class RequestDelegateBuilder(
+    ILogger<RequestDelegateBuilder> logger,
+    IResponseBodyParser bodyParser,
+    IParameterProcessor parameterProcessor,
+    RecyclableMemoryStreamManager memoryStreamManager) : IRequestDelegateBuilder
+{
+    public RequestDelegate BuildResponse(
+        EndpointResponseDetails responseDetails,
+        List<EndpointForgeParameterDetails> parameters)
+    {
+        return async context =>
+        {
+            logger.LogInformation("Building response headers");
+            context.Response.StatusCode = responseDetails.StatusCode;
+            context.Response.ContentType = GetContentType(responseDetails);
+
+            logger.LogInformation("Building response body and writing the response body");
+            if (!string.IsNullOrWhiteSpace(responseDetails.Body))
+            {
+                await using var memoryStream = memoryStreamManager.GetStream();
+                var processedParameters = parameterProcessor.Process(parameters, context);
+                await bodyParser.ProcessResponseBody(memoryStream, responseDetails.Body, processedParameters);
+
+                memoryStream.Seek(0, SeekOrigin.Begin);
+
+                context.Response.ContentLength = memoryStream.Length;
+                await memoryStream.CopyToAsync(context.Response.Body);
+            }
+
+            logger.LogInformation("Response fully written.");
+        };
+    }
+
+    private static string? GetContentType(EndpointResponseDetails responseDetails)
+        => (responseDetails.HasBody(), responseDetails.HasContentType()) switch
+        {
+            (false, _) => null,
+            (true, false) => MediaTypeNames.Text.Plain,
+            (true, true) => responseDetails.ContentType
+        };
+}

--- a/EndpointForge.WebApi/DataSources/EndpointForgeDataSource.cs
+++ b/EndpointForge.WebApi/DataSources/EndpointForgeDataSource.cs
@@ -1,60 +1,22 @@
-using System.Net.Mime;
-using EndpointForge.Abstractions.Extensions;
 using EndpointForge.Abstractions.Interfaces;
 using EndpointForge.Abstractions.Models;
 using Microsoft.AspNetCore.Routing.Patterns;
-using Microsoft.IO;
 
 namespace EndpointForge.WebApi.DataSources;
 
 public class EndpointForgeDataSource(
     ILogger<EndpointForgeDataSource> logger,
-    IResponseBodyParser bodyParser,
-    RecyclableMemoryStreamManager memoryStreamManager) : MutableEndpointDataSource(logger), IEndpointForgeDataSource
+    IRequestDelegateBuilder requestDelegateBuilder) : MutableEndpointDataSource(logger), IEndpointForgeDataSource
 {
     public void AddEndpoint(AddEndpointRequest addEndpointRequest, bool apply = true)
     {
         var endpoint = new RouteEndpointBuilder(
-                BuildResponse(addEndpointRequest.Response, addEndpointRequest.Parameters.ToList()),
-                RoutePatternFactory.Parse(addEndpointRequest.Route),
-                0)
+                requestDelegateBuilder.BuildResponse(addEndpointRequest.Response, addEndpointRequest.Parameters.ToList()),
+                RoutePatternFactory.Parse(addEndpointRequest.Route), 0)
             {
                 Metadata = { new HttpMethodMetadata(addEndpointRequest.Methods) }
             }
             .Build();
         base.AddEndpoint(endpoint, apply);
     }
-
-    private RequestDelegate BuildResponse(
-        EndpointResponseDetails responseDetails,
-        List<EndpointForgeParameterDetails> parameters)
-        => async context =>
-        {
-            logger.LogInformation("Building response headers");
-            context.Response.StatusCode = responseDetails.StatusCode;
-            context.Response.ContentType = GetContentType(responseDetails);
-
-            logger.LogInformation("Building response body and writing the response body");
-            if (!string.IsNullOrWhiteSpace(responseDetails.Body))
-            {
-                await using var memoryStream = memoryStreamManager.GetStream();
-                await bodyParser.ProcessResponseBody(memoryStream, responseDetails.Body, parameters);
-
-                memoryStream.Seek(0, SeekOrigin.Begin);
-
-                context.Response.ContentLength = memoryStream.Length;
-                await memoryStream.CopyToAsync(context.Response.Body);
-            }
-
-            logger.LogInformation("Response fully written.");
-        };
-
-
-    private static string? GetContentType(EndpointResponseDetails responseDetails)
-        => (responseDetails.HasBody(), responseDetails.HasContentType()) switch
-        {
-            (false, _) => null,
-            (true, false) => MediaTypeNames.Text.Plain,
-            (true, true) => responseDetails.ContentType
-        };
 }

--- a/EndpointForge.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/EndpointForge.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -2,8 +2,10 @@ using EndpointForge.Abstractions.Generators;
 using EndpointForge.WebApi.DataSources;
 using EndpointForge.WebApi.Managers;
 using EndpointForge.Abstractions.Interfaces;
+using EndpointForge.WebApi.Builders;
 using EndpointForge.WebApi.Factories;
 using EndpointForge.WebApi.Parsers;
+using EndpointForge.WebApi.Processors;
 using EndpointForge.WebApi.Rules;
 using Microsoft.IO;
 
@@ -23,6 +25,8 @@ public static class ServiceCollectionExtensions
             .AddSingleton<IEndpointForgeDataSource, EndpointForgeDataSource>()
             .AddSingleton<IEndpointForgeManager, EndpointForgeManager>()
             .AddSingleton<IResponseBodyParser, ResponseBodyParser>()
+            .AddSingleton<IRequestDelegateBuilder, RequestDelegateBuilder>()
+            .AddSingleton<IParameterProcessor, ParameterProcessor>()
             .AddSingleton<IEndpointForgeRuleFactory, EndpointForgeRuleFactory>();
 
     private static IServiceCollection AddGenerators(this IServiceCollection services) 

--- a/EndpointForge.WebApi/Parsers/ResponseBodyParser.cs
+++ b/EndpointForge.WebApi/Parsers/ResponseBodyParser.cs
@@ -10,21 +10,12 @@ public class ResponseBodyParser(
     public async Task ProcessResponseBody(
         Stream stream, 
         string responseBody, 
-        List<EndpointForgeParameterDetails> parameters)
+        Dictionary<string, string> parameters)
     {
         logger.LogInformation("Processing Response Body");
         var streamWriter = new StreamWriter(stream);
         var bodySpan = responseBody.AsSpan();
         var lastWrittenIndex = 0;
-
-        var processedParameters = new Dictionary<string, string>();
-        foreach (var parameter in parameters)
-        {
-            if (parameter.Type == "static")
-            {
-                processedParameters.Add(parameter.Identifier, parameter.Value);
-            }
-        }
 
         for (var readIndex = 0; readIndex < bodySpan.Length; readIndex++)
         {
@@ -46,7 +37,7 @@ public class ResponseBodyParser(
             readIndex++;
             var placeholderName = bodySpan[startOfPlaceholderNameIndex..readIndex];
 
-            if (!TryInvokeRule(streamWriter, placeholderName, processedParameters))
+            if (!TryInvokeRule(streamWriter, placeholderName, parameters))
             {
                 WritePlaceholder(streamWriter, placeholderName);
             }

--- a/EndpointForge.WebApi/Processors/ParameterProcessor.cs
+++ b/EndpointForge.WebApi/Processors/ParameterProcessor.cs
@@ -1,0 +1,27 @@
+using EndpointForge.Abstractions.Interfaces;
+using EndpointForge.Abstractions.Models;
+
+namespace EndpointForge.WebApi.Processors;
+
+public class ParameterProcessor : IParameterProcessor
+{
+    public Dictionary<string, string> Process(List<EndpointForgeParameterDetails> parameters, HttpContext context)
+    {
+        var processedParameters = new Dictionary<string, string>();
+        foreach (var parameter in parameters)
+        {
+            switch (parameter.Type)
+            {
+                case "static":
+                    processedParameters.Add(parameter.Identifier, parameter.Value);
+                    break;
+                case "header":
+                    if (context.Request.Headers.TryGetValue(parameter.Identifier, out var header))
+                        processedParameters.Add(parameter.Value, header.ToString());
+                    break;
+            }
+        }
+
+        return processedParameters;
+    }
+}

--- a/EndpointForge.WebApi/Program.cs
+++ b/EndpointForge.WebApi/Program.cs
@@ -48,7 +48,7 @@ internal class Program
     {
         logger.LogInformation("Add endpoint request received.");
         var addEndpointRequest = await httpRequest.TryDeserializeRequestAsync<AddEndpointRequest>();
-
+        
         logger.LogInformation("Deserialized AddEndpointRequest.");
         return await endpointManager.TryAddEndpointAsync(addEndpointRequest);
     }


### PR DESCRIPTION
* Capture the headers as parameters, and process them in the request delegate.
* Refactor for clean code and extract functionality to own classes for injecting
* Update `AddEndpointForge`