### PR TITLE
Update validation to use fluent validator

### DIFF
--- a/EndpointForge.Abstractions/Interfaces/IResponseBodyParser.cs
+++ b/EndpointForge.Abstractions/Interfaces/IResponseBodyParser.cs
@@ -1,5 +1,3 @@
-using EndpointForge.Abstractions.Models;
-
 namespace EndpointForge.Abstractions.Interfaces;
 
 public interface IResponseBodyParser

--- a/EndpointForge.Abstractions/Models/AddEndpointRequest.cs
+++ b/EndpointForge.Abstractions/Models/AddEndpointRequest.cs
@@ -1,5 +1,3 @@
-using System.Collections.Immutable;
-
 namespace EndpointForge.Abstractions.Models;
 
 public record AddEndpointRequest

--- a/EndpointForge.Abstractions/Models/EndpointForgeParameterDetails.cs
+++ b/EndpointForge.Abstractions/Models/EndpointForgeParameterDetails.cs
@@ -1,3 +1,3 @@
 namespace EndpointForge.Abstractions.Models;
 
-public record EndpointForgeParameterDetails(string Type, string Identifier, string Value);
+public record EndpointForgeParameterDetails(string Type, string Name, string Value);

--- a/EndpointForge.Abstractions/Models/EndpointResponseDetails.cs
+++ b/EndpointForge.Abstractions/Models/EndpointResponseDetails.cs
@@ -5,7 +5,7 @@ namespace EndpointForge.Abstractions.Models;
 public class EndpointResponseDetails
 {
     public int StatusCode { get; set; } = 200;
-    public string? ContentType { get; set; }
+    public string? ContentType { get; init; }
     public string? Body {get; set; }
 
     [ExcludeFromCodeCoverage]

--- a/EndpointForge.IntegrationTests/EndpointTests/AddEndpointTests.cs
+++ b/EndpointForge.IntegrationTests/EndpointTests/AddEndpointTests.cs
@@ -1,4 +1,6 @@
 using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
 using EndpointForge.IntegrationTests.Fixtures;
 using EndpointForge.Abstractions.Models;
 using FluentAssertions;
@@ -50,8 +52,10 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-        var response = await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        var response = await httpClient.PostAsync(AddEndpointRoute, content);
         var responseBody = await response.Content.ReadFromJsonAsync<ErrorResponse>();
 
         Assert.Multiple(
@@ -78,8 +82,10 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-        var response = await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        var response = await httpClient.PostAsync(AddEndpointRoute, content);
         var responseBody = await response.Content.ReadFromJsonAsync<ErrorResponse>();
 
         Assert.Multiple(
@@ -88,7 +94,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
     }
     
     [Fact]
-    public async Task When_CallingAddEndpointWithMSingleEmptyElement_Expect_UnprocessableEntityWithSingleError()
+    public async Task When_CallingAddEndpointWithSingleEmptyElement_Expect_UnprocessableEntityWithSingleError()
     {
         var addEndpointRequest = new
         {
@@ -101,12 +107,14 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             Message = "Request contains invalid JSON body which cannot be processed.",
             Errors = new[]
             {
-                "Endpoint request `methods` contains no entries"
+                "Endpoint request `methods` contains no entries."
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-        var response = await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        var response = await httpClient.PostAsync(AddEndpointRoute, content);
         var responseBody = await response.Content.ReadFromJsonAsync<ErrorResponse>();
 
         Assert.Multiple(
@@ -128,13 +136,15 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             Message = "Request contains invalid JSON body which cannot be processed.",
             Errors = new[]
             {
-                "Endpoint request `route` is empty or whitespace",
-                "Endpoint request `methods` contains no entries"
+                "Endpoint request `route` is empty or whitespace.",
+                "Endpoint request `methods` contains no entries."
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-        var response = await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        var response = await httpClient.PostAsync(AddEndpointRoute, content);
         var responseBody = await response.Content.ReadFromJsonAsync<ErrorResponse>();
 
         Assert.Multiple(
@@ -150,10 +160,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
         var addEndpointRequest = new
         {
             Route = "/test-endpoint-conflict",
-            Methods = new[]
-            {
-                "GET"
-            }
+            Methods = new[] { "GET" }
         };
         var expectedResponseBody = new
         {
@@ -164,9 +171,12 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
-        await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-        var response = await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        await httpClient.PostAsync(AddEndpointRoute, content);
+
+        var response = await httpClient.PostAsync(AddEndpointRoute, content);
         var responseBody = await response.Content.ReadFromJsonAsync<ErrorResponse>();
 
         Assert.Multiple(
@@ -189,8 +199,10 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-        var response = await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        var response = await httpClient.PostAsync(AddEndpointRoute, content);
         
         Assert.Multiple(
             () => response.StatusCode.Should().Be(HttpStatusCode.Created),
@@ -217,8 +229,10 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-        await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        await httpClient.PostAsync(AddEndpointRoute, content);
         var response = await httpClient.GetAsync(addEndpointRequest.Route);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -240,8 +254,10 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-        await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        await httpClient.PostAsync(AddEndpointRoute, content);
         var response = await httpClient.GetAsync(addEndpointRequest.Route);
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -259,8 +275,10 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-        await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        await httpClient.PostAsync(AddEndpointRoute, content);
         var response = await httpClient.GetAsync(addEndpointRequest.Route);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -282,8 +300,10 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
-        
-        await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+
+        await httpClient.PostAsync(AddEndpointRoute, content);
         var response = await httpClient.PostAsync(addEndpointRequest.Route, null);
 
         response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
@@ -302,8 +322,10 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-        await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        await httpClient.PostAsync(AddEndpointRoute, content);
         var getResponse = await httpClient.GetAsync(addEndpointRequest.Route);
         var postResponse = await httpClient.PostAsync(addEndpointRequest.Route, null);
 
@@ -332,8 +354,10 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-        await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        await httpClient.PostAsync(AddEndpointRoute, content);
         var response = await httpClient.GetAsync(addEndpointRequest.Route);
         var responseBody = await response.Content.ReadAsStringAsync();
 
@@ -360,8 +384,10 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
-        
-        await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+
+        await httpClient.PostAsync(AddEndpointRoute, content);
         var response = await httpClient.GetAsync(addEndpointRequest.Route);
         var responseBody = await response.Content.ReadAsStringAsync();
 
@@ -389,8 +415,10 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-        await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        await httpClient.PostAsync(AddEndpointRoute, content);
         var response = await httpClient.GetAsync(addEndpointRequest.Route);
         var responseBody = await response.Content.ReadAsStringAsync();
 
@@ -409,14 +437,11 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
         var addEndpointRequest = new
         {
             Route = "/test-endpoint-with-static-parameter",
-            Methods = new[]
-            {
-                "GET"
-            },
+            Methods = new[] { "GET" },
             Response = new
             {
-                StatusCode = 201,
-                ContentType = "text/test-type",
+                StatusCode = 200,
+                ContentType = "application/json",
                 Body = "{{insert:parameter:test-parameter}}"
             },
             Parameters = new[]
@@ -424,7 +449,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 new
                 {
                     Type = "static",
-                    Identifier = "test-parameter",
+                    Name = "test-parameter",
                     Value = "test-value"
                     
                 }
@@ -433,6 +458,10 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
 
         await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+
+        await httpClient.PostAsync(AddEndpointRoute, content);
         var response = await httpClient.GetAsync(addEndpointRequest.Route);
         var responseBody = await response.Content.ReadAsStringAsync();
         
@@ -447,10 +476,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
         var addEndpointRequest = new
         {
             Route = "/test-endpoint-with-header-value",
-            Methods = new[]
-            {
-                "GET"
-            },
+            Methods = new[] { "GET" },
             Response = new
             {
                 StatusCode = 201,
@@ -462,16 +488,17 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 new
                 {
                     Type = "header",
-                    Identifier = "XCustom-Header",
+                    Name = "XCustom-Header",
                     Value = "test-header-parameter"
-                    
                 }
             }
         };
         using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
         httpClient.DefaultRequestHeaders.Add("XCustom-Header", headerValue);
+        var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-        await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
+        await httpClient.PostAsync(AddEndpointRoute, content);
         var response = await httpClient.GetAsync(addEndpointRequest.Route);
         var responseBody = await response.Content.ReadAsStringAsync();
         

--- a/EndpointForge.WebApi.Tests/Attributes/StringEmptyOrWhitespaceInlineDataAttribute.cs
+++ b/EndpointForge.WebApi.Tests/Attributes/StringEmptyOrWhitespaceInlineDataAttribute.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace EndpointForge.WebApi.Tests.Attributes;
+
+[ExcludeFromCodeCoverage]
+public class StringEmptyOrWhitespaceInlineDataAttribute : DataAttribute
+{
+    public override IEnumerable<object[]> GetData(MethodInfo testMethod) => [[""], [" "], ["\t"], ["\n"]];
+}

--- a/EndpointForge.WebApi.Tests/Builders/RequestDelegateBuilderTests.cs
+++ b/EndpointForge.WebApi.Tests/Builders/RequestDelegateBuilderTests.cs
@@ -134,13 +134,13 @@ public class RequestDelegateBuilderTests
         {
             StatusCode = 201,
             Body = "test-body",
-            ContentType = "application/json",
+            ContentType = "application/json"
         };
         var parameters = new List<EndpointForgeParameterDetails>
         {
-            new("static", "test-parameter", "test-parameter-value"),
+            new("insert", "test-parameter", "test-parameter-value")
         };
-        var expectedParameterDictionary = new Dictionary<string, string>()
+        var expectedParameterDictionary = new Dictionary<string, string>
         {
             { "test-parameter", "test-parameter-value" }
         };

--- a/EndpointForge.WebApi.Tests/EndpointForge.WebApi.Tests.csproj
+++ b/EndpointForge.WebApi.Tests/EndpointForge.WebApi.Tests.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
         <PackageReference Include="FluentAssertions" Version="7.0.0" />
+        <PackageReference Include="FluentValidation.Validators.UnitTestExtension" Version="1.11.0.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.0"/>

--- a/EndpointForge.WebApi.Tests/Parsers/ResponseBodyParserTests.cs
+++ b/EndpointForge.WebApi.Tests/Parsers/ResponseBodyParserTests.cs
@@ -22,7 +22,7 @@ public class ResponseBodyParserTests
         var responseBodyParser = new ResponseBodyParser(StubLogger, StubEndpointForgeRuleFactory);
         var stream = new MemoryStream();
         
-        await responseBodyParser.ProcessResponseBody(stream, body, new());
+        await responseBodyParser.ProcessResponseBody(stream, body, new Dictionary<string, string>());
         
         stream.Seek(0, SeekOrigin.Begin);
         var responseBody = await new StreamReader(stream).ReadToEndAsync();
@@ -37,7 +37,7 @@ public class ResponseBodyParserTests
         var responseBodyParser = new ResponseBodyParser(StubLogger, StubEndpointForgeRuleFactory);
         var stream = new MemoryStream();
         
-        await responseBodyParser.ProcessResponseBody(stream, body, new());
+        await responseBodyParser.ProcessResponseBody(stream, body, new Dictionary<string, string>());
         
         stream.Seek(0, SeekOrigin.Begin);
         var responseBody = await new StreamReader(stream).ReadToEndAsync();
@@ -52,7 +52,7 @@ public class ResponseBodyParserTests
         var responseBodyParser = new ResponseBodyParser(StubLogger, StubEndpointForgeRuleFactory);
         var stream = new MemoryStream();
         
-        await responseBodyParser.ProcessResponseBody(stream, body, new());
+        await responseBodyParser.ProcessResponseBody(stream, body, new Dictionary<string, string>());
         
         stream.Seek(0, SeekOrigin.Begin);
         var responseBody = await new StreamReader(stream).ReadToEndAsync();
@@ -68,7 +68,7 @@ public class ResponseBodyParserTests
         var responseBodyParser = new ResponseBodyParser(StubLogger, StubEndpointForgeRuleFactory);
         var stream = new MemoryStream();
         
-        await responseBodyParser.ProcessResponseBody(stream, body, new());
+        await responseBodyParser.ProcessResponseBody(stream, body, new Dictionary<string, string>());
         
         stream.Seek(0, SeekOrigin.Begin);
         var responseBody = await new StreamReader(stream).ReadToEndAsync();
@@ -85,7 +85,7 @@ public class ResponseBodyParserTests
         var responseBodyParser = new ResponseBodyParser(StubLogger, stubEndpointForgeRuleFactory);
         var stream = new MemoryStream();
         
-        await responseBodyParser.ProcessResponseBody(stream, body, new());
+        await responseBodyParser.ProcessResponseBody(stream, body, new Dictionary<string, string>());
         
         stream.Seek(0, SeekOrigin.Begin);
         var responseBody = await new StreamReader(stream).ReadToEndAsync();
@@ -128,7 +128,7 @@ public class ResponseBodyParserTests
         var responseBodyParser = new ResponseBodyParser(StubLogger, stubEndpointForgeRuleFactory);
         var stream = new MemoryStream();
         
-        await responseBodyParser.ProcessResponseBody(stream, body, new());
+        await responseBodyParser.ProcessResponseBody(stream, body, new Dictionary<string, string>());
         
         stream.Seek(0, SeekOrigin.Begin);
         var responseBody = await new StreamReader(stream).ReadToEndAsync();
@@ -146,7 +146,7 @@ public class ResponseBodyParserTests
         var responseBodyParser = new ResponseBodyParser(StubLogger, stubEndpointForgeRuleFactory);
         var stream = new MemoryStream();
         
-        await responseBodyParser.ProcessResponseBody(stream, body, new());
+        await responseBodyParser.ProcessResponseBody(stream, body, new Dictionary<string, string>());
         
         stream.Seek(0, SeekOrigin.Begin);
         var responseBody = await new StreamReader(stream).ReadToEndAsync();

--- a/EndpointForge.WebApi.Tests/Processors/ParameterProcessorTests.cs
+++ b/EndpointForge.WebApi.Tests/Processors/ParameterProcessorTests.cs
@@ -30,15 +30,15 @@ public class ParameterProcessorTests
     {
         var parameters = new List<EndpointForgeParameterDetails>
         {
-            new("header", "XCustom-Header", "parameterName")
+            new("header", "XCustom-Header", "test-parameter-name")
         };
         var expectedParameterDictionary = new Dictionary<string, object>
         {
-            { "parameterName", "parameter-value" }
+            { "test-parameter-name", "test-parameter-value" }
         };
         var parameterProcessor = new ParameterProcessor();
         var httpContext = new DefaultHttpContext();
-        httpContext.Request.Headers.Append("XCustom-Header", "parameter-value");
+        httpContext.Request.Headers.Append("XCustom-Header", "test-parameter-value");
         
         var processedParameterDictionary = parameterProcessor.Process(parameters, httpContext);
         

--- a/EndpointForge.WebApi.Tests/Validators/AddEndpointRequestValidatorTests.cs
+++ b/EndpointForge.WebApi.Tests/Validators/AddEndpointRequestValidatorTests.cs
@@ -1,0 +1,154 @@
+using EndpointForge.Abstractions.Models;
+using EndpointForge.WebApi.Tests.Attributes;
+using EndpointForge.WebApi.Validators;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+
+namespace EndpointForge.WebApi.Tests.Validators;
+
+// Its recommend to supply a real validator instance instead of mocking, and supply it with bad data.
+// https://docs.fluentvalidation.net/en/latest/testing.html#mocking
+public class AddEndpointRequestValidatorTests
+    {
+        private readonly AddEndpointRequestValidator _endpointRequestValidator;
+
+        public AddEndpointRequestValidatorTests()
+        {
+            var parameterValidator = new EndpointForgeParameterDetailsValidator();
+            _endpointRequestValidator = new AddEndpointRequestValidator(parameterValidator);
+        }
+
+        #region Route Tests
+        [Theory]
+        [InlineData("/test-route/{id:int}")]
+        [InlineData("/test-route/test-index")]
+        [InlineData("/test-route/{test-parameter}")]
+        public void When_RouteIsValid_Expect_NoValidationError(string route)
+        {
+            var model = new AddEndpointRequest
+            {
+                Route = route,
+                Methods = []
+            };
+
+            var result = _endpointRequestValidator.TestValidate(model);
+
+            result.ShouldNotHaveValidationErrorFor(x => x.Route);
+        }
+
+        [Theory]
+        [InlineData("/test-route/{id:in")]
+        [InlineData("//test-route/test-index")]
+        [InlineData("//test-route")]
+        public void When_RouteIsInvalid_Expect_ValidationError(string route)
+        {
+            var model = new AddEndpointRequest
+            {
+                Route = route,
+                Methods = ["GET"]
+            };
+            
+            var result = _endpointRequestValidator.TestValidate(model);
+            
+            result.ShouldHaveValidationErrorFor(x => x.Route)
+                .WithErrorMessage($"Endpoint request `route` is an invalid route: {route}.");
+            
+        }
+        
+        [Theory]
+        [StringEmptyOrWhitespaceInlineData]
+        public void When_RouteIsEmpty_Expect_ValidationError(string route)
+        {
+            var model = new AddEndpointRequest
+            {
+                Route = route,
+                Methods = []
+            };
+            
+            var result = _endpointRequestValidator.TestValidate(model);
+            
+            result.ShouldHaveValidationErrorFor(x => x.Route)
+                .WithErrorMessage("Endpoint request `route` is empty or whitespace.");
+        }
+
+        #endregion
+
+        #region Methods Tests
+        [Theory]
+        [InlineData("GET")]
+        [InlineData("POST", "PUT")]
+        [InlineData("DELETE")]
+        public void When_MethodsAreValid_Expect_NoValidationError(params string[] methods)
+        {
+            var model = new AddEndpointRequest
+            {
+                Route = "/test-route",
+                Methods = methods.ToList()
+            };
+
+            var result = _endpointRequestValidator.TestValidate(model);
+
+            result.ShouldNotHaveValidationErrorFor(x => x.Methods);
+        }
+
+        [Fact]
+        public void When_MethodsAreEmpty_Expect_ValidationError()
+        {
+            var model = new AddEndpointRequest
+            {
+                Route = "/test-route",
+                Methods = []
+            };
+            
+            var result = _endpointRequestValidator.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(x => x.Methods)
+                  .WithErrorMessage("Endpoint request `methods` contains no entries.");
+        }
+        #endregion
+
+        #region Parameters Tests
+
+        [Fact]
+        public void When_ParametersAreValid_Expect_NoValidationError()
+        {
+            var validParameter = new EndpointForgeParameterDetails("static", "test-parameter-name", "test-value");
+            
+            var model = new AddEndpointRequest
+            {
+                Route = "/test-route",
+                Methods = ["GET"],
+                Parameters = [validParameter]
+            };
+            
+            var result = _endpointRequestValidator.TestValidate(model);
+
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void When_ParametersAreInvalid_Expect_ValidationError()
+        {
+            var invalidParameter = new EndpointForgeParameterDetails("invalid-type", "", "");
+
+            var model = new AddEndpointRequest
+            {
+                Route = "/test-route",
+                Methods = ["GET"],
+                Parameters = [invalidParameter]
+            };
+            
+            var result = _endpointRequestValidator.TestValidate(model);
+
+            result.Should().NotBeNull();
+            
+            result.Errors.Should().HaveCount(3);
+            result.ShouldHaveValidationErrorFor("Parameters[0].Type")
+                .WithErrorMessage("Parameter `Type` is not valid (invalid-type).");
+            result.ShouldHaveValidationErrorFor("Parameters[0].Name")
+                .WithErrorMessage("Parameter `Name` cannot be empty.");
+            result.ShouldHaveValidationErrorFor("Parameters[0].Value")
+                .WithErrorMessage("Parameter `Value` cannot be empty.");
+        }
+        #endregion
+    }

--- a/EndpointForge.WebApi.Tests/Validators/EndpointForgeParameterDetailsValidatorTests.cs
+++ b/EndpointForge.WebApi.Tests/Validators/EndpointForgeParameterDetailsValidatorTests.cs
@@ -1,0 +1,89 @@
+using EndpointForge.Abstractions.Models;
+using EndpointForge.WebApi.Tests.Attributes;
+using EndpointForge.WebApi.Validators;
+using FluentValidation.TestHelper;
+
+namespace EndpointForge.WebApi.Tests.Validators;
+
+public class EndpointForgeParameterDetailsValidatorTests
+{
+    private readonly EndpointForgeParameterDetailsValidator _validator = new();
+
+    #region Name Tests
+    [Fact]
+    public void When_NameIsNotEmpty_Expect_NoValidationError()
+    {
+        var model = new EndpointForgeParameterDetails("","test-parameter-name", "");
+
+        var result = _validator.TestValidate(model);
+        
+        result.ShouldNotHaveValidationErrorFor(p => p.Name);
+    }
+    
+    [Theory]
+    [StringEmptyOrWhitespaceInlineData]
+    public void When_NameIsEmpty_Expect_ValidationError(string name)
+    {
+        var model = new EndpointForgeParameterDetails("", name, "");
+
+        var result = _validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(p => p.Name)
+            .WithErrorMessage("Parameter `Name` cannot be empty.");
+    }
+    #endregion
+    
+    #region Type Tests
+    [Theory]
+    [InlineData("static")]
+    [InlineData("header")]
+    public void When_TypeIsValid_Expect_NoValidationError(string type)
+    {
+        var details = new EndpointForgeParameterDetails(type, "", "");
+
+        var result = _validator.TestValidate(details);
+
+        result.ShouldNotHaveValidationErrorFor(p => p.Type);
+    }
+    
+    [Theory]
+    [InlineData("query")]
+    [InlineData("body")]
+    [StringEmptyOrWhitespaceInlineData]
+    public void When_TypeIsInvalid_Expect_ValidationError(string type)
+    {
+        var model = new EndpointForgeParameterDetails(type, "", "");
+
+        var result = _validator.TestValidate(model);
+        
+        result.ShouldHaveValidationErrorFor(p => p.Type)
+            .WithErrorMessage($"Parameter `Type` is not valid ({type}).");
+    }
+    #endregion
+    
+    #region Value Tests
+    [Fact]
+    public void When_ValueIsNotEmpty_Expect_NoValidationError()
+    {
+        var model = new EndpointForgeParameterDetails("","", "test-value");
+
+        var result = _validator.TestValidate(model);
+        
+        result.ShouldNotHaveValidationErrorFor(p => p.Value);
+    }
+    
+    [Theory]
+    [StringEmptyOrWhitespaceInlineData]
+    public void When_ValueIsEmpty_Expect_ValidationError(string value)
+    {
+        var model = new EndpointForgeParameterDetails("", "", value);
+
+        var result = _validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(p => p.Value)
+            .WithErrorMessage("Parameter `Value` cannot be empty.");
+    }
+    #endregion
+}
+
+

--- a/EndpointForge.WebApi/EndpointForge.WebApi.csproj
+++ b/EndpointForge.WebApi/EndpointForge.WebApi.csproj
@@ -8,6 +8,8 @@
 
     <ItemGroup>
         <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
+        <PackageReference Include="FluentValidation" Version="11.11.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rc.1.24452.1"/>
     </ItemGroup>
 

--- a/EndpointForge.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/EndpointForge.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -2,11 +2,14 @@ using EndpointForge.Abstractions.Generators;
 using EndpointForge.WebApi.DataSources;
 using EndpointForge.WebApi.Managers;
 using EndpointForge.Abstractions.Interfaces;
+using EndpointForge.Abstractions.Models;
 using EndpointForge.WebApi.Builders;
 using EndpointForge.WebApi.Factories;
 using EndpointForge.WebApi.Parsers;
 using EndpointForge.WebApi.Processors;
 using EndpointForge.WebApi.Rules;
+using EndpointForge.WebApi.Validators;
+using FluentValidation;
 using Microsoft.IO;
 
 namespace EndpointForge.WebApi.Extensions;
@@ -16,6 +19,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddEndpointForge(this IServiceCollection services)
         => services
             .AddCoreServices()
+            .AddValidators()
             .AddGenerators()
             .AddRules();
 
@@ -37,4 +41,9 @@ public static class ServiceCollectionExtensions
         => services
             .AddSingleton<IEndpointForgeRule, GenerateGuidRule>()
             .AddSingleton<IEndpointForgeRule, InsertParameterRule>();
+
+    private static IServiceCollection AddValidators(this IServiceCollection services)
+        => services
+            .AddTransient<IValidator<AddEndpointRequest>, AddEndpointRequestValidator>()
+            .AddTransient<IValidator<EndpointForgeParameterDetails>, EndpointForgeParameterDetailsValidator>();
 }

--- a/EndpointForge.WebApi/Parsers/ResponseBodyParser.cs
+++ b/EndpointForge.WebApi/Parsers/ResponseBodyParser.cs
@@ -1,5 +1,4 @@
 using EndpointForge.Abstractions.Interfaces;
-using EndpointForge.Abstractions.Models;
 
 namespace EndpointForge.WebApi.Parsers;
 

--- a/EndpointForge.WebApi/Processors/ParameterProcessor.cs
+++ b/EndpointForge.WebApi/Processors/ParameterProcessor.cs
@@ -13,10 +13,10 @@ public class ParameterProcessor : IParameterProcessor
             switch (parameter.Type)
             {
                 case "static":
-                    processedParameters.Add(parameter.Identifier, parameter.Value);
+                    processedParameters.Add(parameter.Name, parameter.Value);
                     break;
                 case "header":
-                    if (context.Request.Headers.TryGetValue(parameter.Identifier, out var header))
+                    if (context.Request.Headers.TryGetValue(parameter.Name, out var header))
                         processedParameters.Add(parameter.Value, header.ToString());
                     break;
             }

--- a/EndpointForge.WebApi/Validators/AddEndpointRequestValidator.cs
+++ b/EndpointForge.WebApi/Validators/AddEndpointRequestValidator.cs
@@ -1,0 +1,37 @@
+using EndpointForge.Abstractions.Models;
+using FluentValidation;
+using Microsoft.AspNetCore.Routing.Patterns;
+
+namespace EndpointForge.WebApi.Validators;
+
+public class AddEndpointRequestValidator : AbstractValidator<AddEndpointRequest>
+{
+    public AddEndpointRequestValidator(IValidator<EndpointForgeParameterDetails> endpointForgeParameterDetailsValidator)
+    {
+        RuleFor(x => x.Route)
+            .NotEmpty()
+            .WithMessage("Endpoint request `route` is empty or whitespace.")
+            .Must(BeAValidRoute)
+            .WithMessage(details => $"Endpoint request `route` is an invalid route: {details.Route}.");
+
+        RuleFor(x => x.Methods)
+            .NotEmpty()
+            .WithMessage("Endpoint request `methods` contains no entries.");
+
+        RuleForEach(x => x.Parameters)
+            .SetValidator(endpointForgeParameterDetailsValidator);
+    }
+
+    private bool BeAValidRoute(string route)
+    {
+        try
+        {
+            _ = RoutePatternFactory.Parse(route);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/EndpointForge.WebApi/Validators/EndpointForgeParameterDetailsValidator.cs
+++ b/EndpointForge.WebApi/Validators/EndpointForgeParameterDetailsValidator.cs
@@ -1,0 +1,23 @@
+using EndpointForge.Abstractions.Models;
+using FluentValidation;
+
+namespace EndpointForge.WebApi.Validators;
+
+public class EndpointForgeParameterDetailsValidator : AbstractValidator<EndpointForgeParameterDetails>
+{
+    private readonly List<string> _types = ["static", "header"];
+
+    public EndpointForgeParameterDetailsValidator()
+    {
+        RuleFor(p => p.Type)
+            .Must(BeAValidType)
+            .WithMessage(details => $"Parameter `Type` is not valid ({details.Type}).");
+        RuleFor(p => p.Name)
+            .NotEmpty()
+            .WithMessage("Parameter `Name` cannot be empty.");
+        RuleFor(p => p.Value)
+            .NotEmpty()
+            .WithMessage("Parameter `Value` cannot be empty.");
+    }
+    private bool BeAValidType(string type) => _types.Contains(type);
+}


### PR DESCRIPTION
* Remove manual validation steps.
* Add content length validation
* Add tests for validators
* Update remaining tests to handle content length having to be set, as httpClient.PostAsJsonAsync does not always provide content length