### PR TITLE
Update return type from AddEndpoint

### DIFF
--- a/EndpointForge.IntegrationTests/EndpointTests/AddEndpointTests.cs
+++ b/EndpointForge.IntegrationTests/EndpointTests/AddEndpointTests.cs
@@ -468,7 +468,6 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
          responseBody.Should().Be("test-value");
     }
     
-        
     [Fact]
     public async Task When_ProvidingHeaderParameter_Expect_EndpointResponseBodyToContainThatHeaderValue()
     {

--- a/EndpointForge.WebApi/Program.cs
+++ b/EndpointForge.WebApi/Program.cs
@@ -41,7 +41,7 @@ internal class Program
                 return await endpointManager.TryAddEndpointAsync(addEndpointRequest);
             })
             .Accepts<AddEndpointRequest>(contentType: "application/json")
-            .Produces<AddEndpointRequest>(StatusCodes.Status201Created)
+            .Produces(StatusCodes.Status201Created)
             .Produces<ErrorResponse>(StatusCodes.Status400BadRequest)
             .Produces<ErrorResponse>(StatusCodes.Status409Conflict)
             .Produces<ErrorResponse>(StatusCodes.Status422UnprocessableEntity);


### PR DESCRIPTION
Update return type from AddEndpoint to reflect that the full response body is not being returned. Remove unnecessary whitespace