### PR TITLE
Refactor AddEndpointRequest to move helper method on record to extension method

### DIFF
--- a/EndpointForge.Models/AddEndpointRequest.cs
+++ b/EndpointForge.Models/AddEndpointRequest.cs
@@ -6,7 +6,4 @@ public record AddEndpointRequest
     public required List<string> Methods { get; init; } = [];
     public EndpointResponseDetails Response { get; init; } = new();
     public List<EndpointParameterDetails> Parameters { get; init; } = [];
-    
-    public IEnumerable<EndpointRoutingDetails> GetEndpointRoutingDetails() => 
-        Methods.Select(method => new EndpointRoutingDetails(Route, method));
 }

--- a/EndpointForge.Models/EndpointRoutingDetails.cs
+++ b/EndpointForge.Models/EndpointRoutingDetails.cs
@@ -1,3 +1,0 @@
-namespace EndpointForge.Models;
-
-public record EndpointRoutingDetails(string Route, string Method);

--- a/EndpointForge.WebApi.Tests/Extensions/AddEndpointRequestExtensions.cs
+++ b/EndpointForge.WebApi.Tests/Extensions/AddEndpointRequestExtensions.cs
@@ -1,0 +1,40 @@
+using EndpointForge.Models;
+using EndpointForge.WebApi.Extensions;
+using FluentAssertions;
+
+namespace EndpointForge.WebApi.Tests.Extensions;
+
+public class AddEndpointRequestExtensions
+{
+    [Fact]
+    public void When_GetEndpointRequestDetailsAndSingleMethodIsPresent_Expect_TheRouteAndTheMethodAreReturned()
+    {
+        AddEndpointRequest addEndpointRequest = new()
+        {
+            Route = "/test-route",
+            Methods = ["GET"]
+        };
+
+        var endpointRoutingDetails = addEndpointRequest.GetEndpointRoutingDetails();
+
+        endpointRoutingDetails.Should().BeEquivalentTo([("/test-route", "GET")]);
+    }
+
+    [Fact]
+    public void When_GetEndpointRequestDetailsAndMultipleMethodsArePresent_Expect_ListOfRouteAndMethodAreReturned()
+    {
+        AddEndpointRequest addEndpointRequest = new()
+        {
+            Route = "/test-route",
+            Methods = ["GET", "POST", "PUT"]
+        };
+
+        var endpointRoutingDetails = addEndpointRequest.GetEndpointRoutingDetails();
+
+        endpointRoutingDetails.Should().BeEquivalentTo([
+            ("/test-route", "GET"),
+            ("/test-route", "POST"),
+            ("/test-route", "PUT")
+        ]);
+    }
+}

--- a/EndpointForge.WebApi/Extensions/EndpointRoutingDetailsExtensions.cs
+++ b/EndpointForge.WebApi/Extensions/EndpointRoutingDetailsExtensions.cs
@@ -1,0 +1,10 @@
+using EndpointForge.Models;
+
+namespace EndpointForge.WebApi.Extensions;
+
+public static class EndpointRoutingDetailsExtensions
+{
+    public static IEnumerable<(string Route, string Method)> GetEndpointRoutingDetails(
+        this AddEndpointRequest addEndpointRequest) 
+        => addEndpointRequest.Methods.Select(method => (addEndpointRequest.Route, method));
+}

--- a/EndpointForge.WebApi/Extensions/LoggerExtensions.cs
+++ b/EndpointForge.WebApi/Extensions/LoggerExtensions.cs
@@ -30,16 +30,17 @@ internal static partial class LoggerExtensions
         this ILogger logger,
         [LogProperties(OmitReferenceName = true)] in Models.AddEndpointRequest addEndpointRequest);
 
-    [LoggerMessage(LogLevel.Information, "Endpoint Created: {Details}")]
-    private static partial void EndpointRoutingDetails(
+    [LoggerMessage(LogLevel.Information, "Endpoint Created: Route={Route}, Method={Method}")]
+    private static partial void LogEndpointRoutingDetails(
         this ILogger logger,
-        [LogProperties(OmitReferenceName = true)] in Models.EndpointRoutingDetails details);
+        string route,
+        string method);
 
     public static void LogAddEndpointRequestCompleted(this ILogger logger, Models.AddEndpointRequest addEndpointRequest)
     {
-        foreach (var details in addEndpointRequest.GetEndpointRoutingDetails())
+        foreach (var (route, method) in addEndpointRequest.GetEndpointRoutingDetails())
         {
-            logger.EndpointRoutingDetails(details); 
+            logger.LogEndpointRoutingDetails(route, method); 
         }
         logger.AddEndpointRequest(addEndpointRequest);
     }

--- a/EndpointForge.WebApi/Managers/EndpointForgeManager.cs
+++ b/EndpointForge.WebApi/Managers/EndpointForgeManager.cs
@@ -12,7 +12,7 @@ public class EndpointForgeManager(
     IValidator<AddEndpointRequest> validator) : IEndpointForgeManager
 {
     private const string ConflictMessage = "The requested endpoint has already been added for {0} method";
-    private readonly List<EndpointRoutingDetails> _endpointDetails = [];
+    private readonly List<(string Route, string Method)> _endpointDetails = [];
     private readonly Lock _listLock = new();
     
     public async Task<IResult> TryAddEndpointAsync(AddEndpointRequest addEndpointRequest)


### PR DESCRIPTION
* Refactor `AddEndpointRequest` to move helper method on record to extension method
* Update usages of `AddEndpointRequest` to utilize the refactored extension method
* Removed `EndpointResponseDetails` and replace with (string, string) tuple.