### PR TITLE
Rename 'MutableEndpointDataSource' to `DynamicEndpointDataSource`

### DIFF
--- a/EndpointForge.WebApi.Tests/Extensions/EndpointRouteBuilderExtensionsTests.cs
+++ b/EndpointForge.WebApi.Tests/Extensions/EndpointRouteBuilderExtensionsTests.cs
@@ -14,7 +14,7 @@ public class EndpointRouteBuilderExtensionsTests
     [Fact]
     public void UseEndpointForge_AddsDataSource_WhenServiceIsRegistered()
     {
-        var mockMutableEndpointDataSource = new Mock<MutableEndpointDataSource>(StubLogger)
+        var mockMutableEndpointDataSource = new Mock<DynamicEndpointDataSource>(StubLogger)
             .As<IEndpointForgeDataSource>();
         var mockDataSources = new Mock<ICollection<EndpointDataSource>>();
         var mockServiceProvider = new Mock<IServiceProvider>();

--- a/EndpointForge.WebApi/DataSources/DynamicEndpointDataSource.cs
+++ b/EndpointForge.WebApi/DataSources/DynamicEndpointDataSource.cs
@@ -1,6 +1,6 @@
 namespace EndpointForge.WebApi.DataSources;
 
-public abstract class MutableEndpointDataSource : EndpointDataSource
+public abstract class DynamicEndpointDataSource : EndpointDataSource
 {
     private readonly Lock _endpointsLock = new();
     private readonly Lock _tokenLock = new();
@@ -9,9 +9,9 @@ public abstract class MutableEndpointDataSource : EndpointDataSource
     private CancellationTokenSource _cancellationTokenSource;
     private IChangeToken _changeToken;
 
-    private readonly ILogger<MutableEndpointDataSource> _logger;
+    private readonly ILogger<DynamicEndpointDataSource> _logger;
     
-    protected MutableEndpointDataSource(ILogger<MutableEndpointDataSource> logger)
+    protected DynamicEndpointDataSource(ILogger<DynamicEndpointDataSource> logger)
     {
         _logger = logger;
         _cancellationTokenSource = new CancellationTokenSource();

--- a/EndpointForge.WebApi/DataSources/EndpointForgeDataSource.cs
+++ b/EndpointForge.WebApi/DataSources/EndpointForgeDataSource.cs
@@ -5,7 +5,7 @@ namespace EndpointForge.WebApi.DataSources;
 
 public class EndpointForgeDataSource(
     ILogger<EndpointForgeDataSource> logger,
-    IRequestDelegateBuilder requestDelegateBuilder) : MutableEndpointDataSource(logger), IEndpointForgeDataSource
+    IRequestDelegateBuilder requestDelegateBuilder) : DynamicEndpointDataSource(logger), IEndpointForgeDataSource
 {
     public void AddEndpoint(AddEndpointRequest addEndpointRequest, bool apply = true)
     {


### PR DESCRIPTION
* Rename 'MutableEndpointDataSource' to `DynamicEndpointDataSource` to better match naming conventions.