### PR TITLE
Add parameter type and use statics

### DIFF
--- a/EndpointForge.Abstractions/Constants/ParameterType.cs
+++ b/EndpointForge.Abstractions/Constants/ParameterType.cs
@@ -1,0 +1,52 @@
+namespace EndpointForge.Abstractions.Constants;
+
+/// <summary>
+/// Contains types to verify the type of an EndpointForge parameter.
+/// </summary>
+public static class ParameterType
+{
+    // ReSharper disable ConvertToConstant.Global
+    // These are deliberately `static readonly` and not `const`.  This is so that all consuming assemblies
+    // get the exact same `string` instance and comparisons are optimized.
+
+    /// <summary>
+    ///  EndpointForge parameter type "header"
+    /// </summary>
+    public static readonly string Header = "header";
+    
+    /// <summary>
+    ///  EndpointForge parameter type "static"
+    /// </summary>
+    public static readonly string Static = "static";
+
+    /// <summary>
+    /// Returns a value that indicates if the EndpointForge parameter type is Header.
+    /// </summary>
+    /// <param name="type">EndpointForge parameter type.</param>
+    /// <returns>
+    /// <see langword="true" /> if the type is Header; otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool IsHeader(string type) => Equals(Header, type);
+    
+    /// <summary>
+    /// Returns a value that indicates if the EndpointForge parameter type is Static.
+    /// </summary>
+    /// <param name="type">EndpointForge parameter type.</param>
+    /// <returns>
+    /// <see langword="true" /> if the type is Static; otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool IsStatic(string type) => Equals(Static, type);
+    
+    /// <summary>
+    /// Returns a value that indicates if the EndpointForge parameter types are the same.
+    /// </summary>
+    /// <param name="typeA">The first EndpointForge parameter type to compare.</param>
+    /// <param name="typeB">The second EndpointForge parameter type to compare.</param>
+    /// <returns>
+    /// <see langword="true" /> if the types are the same; otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool Equals(string typeA, string typeB)
+    {
+        return ReferenceEquals(typeA, typeB) || StringComparer.OrdinalIgnoreCase.Equals(typeA, typeB);
+    }
+}

--- a/EndpointForge.Models/GlobalUsings.cs
+++ b/EndpointForge.Models/GlobalUsings.cs
@@ -1,4 +1,3 @@
 // Global using directives
 
-global using System.Diagnostics.CodeAnalysis;
 global using System.Net;

--- a/EndpointForge.WebApi.Tests/Fakes/FakeGeneratorRule.cs
+++ b/EndpointForge.WebApi.Tests/Fakes/FakeGeneratorRule.cs
@@ -5,7 +5,6 @@ namespace EndpointForge.WebApi.Tests.Fakes;
 [ExcludeFromCodeCoverage]
 internal class FakeGeneratorRule(string type = "", string value = "") : IEndpointForgeGeneratorRule
 {
-    public string Instruction => "generate";
     public string Type => type;
     public void Invoke(StreamWriter streamWriter) => streamWriter.Write(value);
 }

--- a/EndpointForge.WebApi.Tests/Fakes/FakeInsertRule.cs
+++ b/EndpointForge.WebApi.Tests/Fakes/FakeInsertRule.cs
@@ -4,8 +4,7 @@ namespace EndpointForge.WebApi.Tests.Fakes;
 
 [ExcludeFromCodeCoverage]
 internal class FakeInsertRule(string type = "") : IEndpointForgeInsertRule
-{
-    public string Instruction => "insert";
+{ 
     public string Type => type;
 
     public void Invoke(StreamWriter streamWriter, ReadOnlySpan<char> value) => streamWriter.Write(value);

--- a/EndpointForge.WebApi.Tests/Managers/EndpointForgeManagerTests.cs
+++ b/EndpointForge.WebApi.Tests/Managers/EndpointForgeManagerTests.cs
@@ -66,7 +66,7 @@ public class EndpointForgeManagerTests
             () => exception.Message.Should().Be("Request contains invalid JSON body which cannot be processed."),
             () => exception.Errors
                 .Should()
-                .BeEquivalentTo("Endpoint request `route` is empty or whitespace."));
+                .BeEquivalentTo($"Endpoint request `{nameof(AddEndpointRequest.Route)}` is empty or whitespace."));
     }
 
     [Fact]
@@ -90,7 +90,7 @@ public class EndpointForgeManagerTests
             () => exception.Message.Should().Be("Request contains invalid JSON body which cannot be processed."),
             () => exception.Errors
                 .Should()
-                .BeEquivalentTo("Endpoint request `methods` contains no entries."));
+                .BeEquivalentTo($"Endpoint request `{nameof(AddEndpointRequest.Methods)}` contains no entries."));
     }
 
     [Fact]

--- a/EndpointForge.WebApi.Tests/Processors/ParameterProcessorTests.cs
+++ b/EndpointForge.WebApi.Tests/Processors/ParameterProcessorTests.cs
@@ -7,15 +7,15 @@ namespace EndpointForge.WebApi.Tests.Processors;
 public class ParameterProcessorTests
 {
     [Fact]
-    public void When_ProcessWithStaticParameter_Expect_ParameterMappedInDictionary()
+    public void When_ProcessWithStaticParameter_Expect_ParameterMappedIntoDictionary()
     {
         var parameters = new List<EndpointParameterDetails>
         {
-            new("static", "identifier", "parameter-value")
+            new("static", "test-parameter-name", "parameter-value")
         };
         var expectedParameterDictionary = new Dictionary<string, object>
         {
-            { "identifier", "parameter-value" }
+            { "test-parameter-name", "parameter-value" }
         };
         var parameterProcessor = new ParameterProcessor();
         var httpContext = new DefaultHttpContext();
@@ -25,7 +25,7 @@ public class ParameterProcessorTests
     }
     
     [Fact]
-    public void When_ProcessWithHeaderParameter_Expect_ParameterMappedFromHeadersInToDictionary()
+    public void When_ProcessWithHeaderParameter_Expect_ParameterMappedFromHeadersIntoDictionary()
     {
         var parameters = new List<EndpointParameterDetails>
         {
@@ -38,6 +38,24 @@ public class ParameterProcessorTests
         var parameterProcessor = new ParameterProcessor();
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Headers.Append("XCustom-Header", "test-parameter-value");
+        
+        var processedParameterDictionary = parameterProcessor.Process(parameters, httpContext);
+        
+        processedParameterDictionary.Should().BeEquivalentTo(expectedParameterDictionary);
+    }
+    
+        
+    [Fact]
+    public void When_ProcessWithRoutePath_Expect_ParameterMappedFromRoutePathIntoDictionary()
+    {
+        List<EndpointParameterDetails> parameters = [];
+        var expectedParameterDictionary = new Dictionary<string, object>
+        {
+            { "path-parameter-name", "path-parameter-value" }
+        };
+        var parameterProcessor = new ParameterProcessor();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.RouteValues.Add("path-parameter-name", "path-parameter-value");
         
         var processedParameterDictionary = parameterProcessor.Process(parameters, httpContext);
         

--- a/EndpointForge.WebApi.Tests/Validators/AddEndpointRequestValidatorTests.cs
+++ b/EndpointForge.WebApi.Tests/Validators/AddEndpointRequestValidatorTests.cs
@@ -51,7 +51,7 @@ public class AddEndpointRequestValidatorTests
             var result = _endpointRequestValidator.TestValidate(model);
             
             result.ShouldHaveValidationErrorFor(x => x.Route)
-                .WithErrorMessage($"Endpoint request `route` is an invalid route: {route}.");
+                .WithErrorMessage($"Endpoint request `{nameof(AddEndpointRequest.Route)}` is an invalid route: {route}.");
             
         }
         
@@ -68,7 +68,7 @@ public class AddEndpointRequestValidatorTests
             var result = _endpointRequestValidator.TestValidate(model);
             
             result.ShouldHaveValidationErrorFor(x => x.Route)
-                .WithErrorMessage("Endpoint request `route` is empty or whitespace.");
+                .WithErrorMessage($"Endpoint request `{nameof(AddEndpointRequest.Route)}` is empty or whitespace.");
         }
 
         #endregion
@@ -103,7 +103,7 @@ public class AddEndpointRequestValidatorTests
             var result = _endpointRequestValidator.TestValidate(model);
 
             result.ShouldHaveValidationErrorFor(x => x.Methods)
-                  .WithErrorMessage("Endpoint request `methods` contains no entries.");
+                  .WithErrorMessage($"Endpoint request `{nameof(AddEndpointRequest.Methods)}` contains no entries.");
         }
         #endregion
 

--- a/EndpointForge.WebApi/Extensions/LoggerExtensions.cs
+++ b/EndpointForge.WebApi/Extensions/LoggerExtensions.cs
@@ -19,7 +19,7 @@ internal static partial class LoggerExtensions
         int statusCode,
         HttpStatusCode statusDescription);
 
-    public static void LogErrorResponse(this ILogger logger, Models.ErrorResponse errorResponse)
+    public static void LogErrorResponse(this ILogger logger, ErrorResponse errorResponse)
     {
         logger.ErrorResponseInformation((int)errorResponse.StatusCode, errorResponse.StatusCode);
         logger.ErrorResponse(errorResponse);

--- a/EndpointForge.WebApi/Processors/ParameterProcessor.cs
+++ b/EndpointForge.WebApi/Processors/ParameterProcessor.cs
@@ -16,9 +16,9 @@ public class ParameterProcessor : IParameterProcessor
 
         foreach (var (type, name, value) in parameters)
         {
-            if (ParameterType.IsHeader(type))
-                processedParameters.Add(name, value);
             if (ParameterType.IsStatic(type))
+                processedParameters.Add(name, value);
+            if (ParameterType.IsHeader(type))
                 if (context.Request.Headers.TryGetValue(name, out var header))
                     processedParameters.Add(value, header.ToString());
         }

--- a/EndpointForge.WebApi/Validators/AddEndpointRequestValidator.cs
+++ b/EndpointForge.WebApi/Validators/AddEndpointRequestValidator.cs
@@ -9,13 +9,13 @@ public class AddEndpointRequestValidator : AbstractValidator<AddEndpointRequest>
     {
         RuleFor(x => x.Route)
             .NotEmpty()
-            .WithMessage("Endpoint request `route` is empty or whitespace.")
+            .WithMessage(details => $"Endpoint request `{nameof(details.Route)}` is empty or whitespace.")
             .Must(BeAValidRoute)
-            .WithMessage(details => $"Endpoint request `route` is an invalid route: {details.Route}.");
+            .WithMessage(details => $"Endpoint request `{nameof(details.Route)}` is an invalid route: {details.Route}.");
 
         RuleFor(x => x.Methods)
             .NotEmpty()
-            .WithMessage("Endpoint request `methods` contains no entries.");
+            .WithMessage(details => $"Endpoint request `{nameof(details.Methods)}` contains no entries.");
 
         RuleForEach(x => x.Parameters)
             .SetValidator(endpointForgeParameterDetailsValidator);

--- a/EndpointForge.WebApi/Validators/EndpointParameterDetailsValidator.cs
+++ b/EndpointForge.WebApi/Validators/EndpointParameterDetailsValidator.cs
@@ -1,3 +1,4 @@
+using EndpointForge.Abstractions.Constants;
 using EndpointForge.Models;
 using FluentValidation;
 
@@ -5,19 +6,19 @@ namespace EndpointForge.WebApi.Validators;
 
 public class EndpointParameterDetailsValidator : AbstractValidator<EndpointParameterDetails>
 {
-    private readonly List<string> _types = ["static", "header"];
+    private readonly List<string> _types = [ ParameterType.Header, ParameterType.Static ];
 
     public EndpointParameterDetailsValidator()
     {
         RuleFor(p => p.Type)
             .Must(BeAValidType)
-            .WithMessage(details => $"Parameter `Type` is not valid ({details.Type}).");
+            .WithMessage(details => $"Parameter `{nameof(details.Type)}` is not valid ({details.Type}).");
         RuleFor(p => p.Name)
             .NotEmpty()
-            .WithMessage("Parameter `Name` cannot be empty.");
+            .WithMessage(details => $"Parameter `{nameof(details.Name)}` cannot be empty.");
         RuleFor(p => p.Value)
             .NotEmpty()
-            .WithMessage("Parameter `Value` cannot be empty.");
+            .WithMessage(details => $"Parameter `{nameof(details.Value)}` cannot be empty.");
     }
     private bool BeAValidType(string type) => _types.Contains(type);
 }


### PR DESCRIPTION
* Create a string enum for `ParameterType`
* Use this in ParameterProcessor.cs
* Update validator to use nameof to allow for method renaming without issues.