### PR TITLE
Change name of Aspire Service for EndpointForge from `webapi` to `EndpointForge`

### DIFF
--- a/EndpointForge.AppHost/Program.cs
+++ b/EndpointForge.AppHost/Program.cs
@@ -1,6 +1,6 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddProject<Projects.EndpointForge_WebApi>("webapi")
+builder.AddProject<Projects.EndpointForge_WebApi>("EndpointForge")
     .WithExternalHttpEndpoints();
 
 builder.Build().Run();

--- a/EndpointForge.IntegrationTests/EndpointForge.IntegrationTests.csproj
+++ b/EndpointForge.IntegrationTests/EndpointForge.IntegrationTests.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Aspire.Hosting.Testing" Version="9.0.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
         <PackageReference Include="FluentAssertions" Version="7.0.0" />
+        <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
         <PackageReference Include="xunit" Version="2.9.2"/>
         <PackageReference Include="xunit.analyzers" Version="1.18.0">

--- a/EndpointForge.IntegrationTests/EndpointTests/AddEndpointTests.cs
+++ b/EndpointForge.IntegrationTests/EndpointTests/AddEndpointTests.cs
@@ -7,9 +7,9 @@ using FluentAssertions;
 
 namespace EndpointForge.IntegrationTests.EndpointTests;
 
-public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebApiFixture>
+public class AddEndpointTests(EndpointForgeFixture endpointForgeFixture) : IClassFixture<EndpointForgeFixture>
 {
-    private const string WebApiName = "webapi";
+    private const string EndpointForgeName = "EndpointForge";
     private const string AddEndpointRoute = "/add-endpoint";
 
     #region Error Result Tests
@@ -21,7 +21,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             StatusCode = HttpStatusCode.BadRequest,
             Message = "Request body was of an unknown type, empty, or is missing required fields."
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
 
         var response = await httpClient.PostAsync(AddEndpointRoute, null);
         var responseBody = await response.Content.ReadFromJsonAsync<ErrorResponse>();
@@ -51,7 +51,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 "was missing required properties including: 'Route'."
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -81,7 +81,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -110,7 +110,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 $"Endpoint request `{nameof(AddEndpointRequest.Methods)}` contains no entries."
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -140,7 +140,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 $"Endpoint request `{nameof(AddEndpointRequest.Methods)}` contains no entries."
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -170,7 +170,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 "The requested endpoint has already been added for GET method"
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -198,7 +198,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 "GET"
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -228,7 +228,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 StatusCode = 400
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -253,7 +253,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 StatusCode = 201
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -274,7 +274,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 "GET"
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -299,7 +299,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 "GET"
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -321,7 +321,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 "POST"
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -353,7 +353,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 StatusCode = 200
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -383,7 +383,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 Body = "String response body."
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -414,7 +414,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 Body = "String response body."
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -455,7 +455,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 }
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
 
         await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
@@ -492,7 +492,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
                 }
             }
         };
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         httpClient.DefaultRequestHeaders.Add("XCustom-Header", headerValue);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
@@ -521,7 +521,7 @@ public class AddEndpointTests(WebApiFixture webApiFixture) : IClassFixture<WebAp
             }
         };
         
-        using var httpClient = webApiFixture.Application.CreateHttpClient(WebApiName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
 
         await httpClient.PostAsJsonAsync(AddEndpointRoute, addEndpointRequest);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);

--- a/EndpointForge.IntegrationTests/Fixtures/EndpointForgeFixture.cs
+++ b/EndpointForge.IntegrationTests/Fixtures/EndpointForgeFixture.cs
@@ -1,20 +1,22 @@
 using Aspire.Hosting;
+using JetBrains.Annotations;
 using Microsoft.Extensions.Hosting;
 
 namespace EndpointForge.IntegrationTests.Fixtures;
 
-// WebApiFixture is used as a class fixture via DI and is not directly instantiated.
-// ReSharper disable once ClassNeverInstantiated.Global
-public class WebApiFixture : IDisposable
+// EndpointForgeFixture is used as a class fixture via DI and is not directly instantiated, however due to that XUnit
+// class fixtures require a parameterless public constructor, it is not possible to make this class abstract.
+[UsedImplicitly]
+public class EndpointForgeFixture : IDisposable
 {
     public readonly DistributedApplication Application;
 
-    public WebApiFixture()
+    public EndpointForgeFixture()
     { 
         var appHost = CreateDefaultAppHost().Result;
         Application = appHost.BuildAsync().Result;
         Application.Start();
-        WaitForRunningState(Application, "webapi")
+        WaitForRunningState(Application, "EndpointForge")
             .ConfigureAwait(ConfigureAwaitOptions.None)
             .GetAwaiter()
             .GetResult();

--- a/EndpointForge.IntegrationTests/StatusTests/ServiceStatusTests.cs
+++ b/EndpointForge.IntegrationTests/StatusTests/ServiceStatusTests.cs
@@ -3,14 +3,14 @@ using FluentAssertions;
 
 namespace EndpointForge.IntegrationTests.StatusTests;
 
-public class ServiceStatusTests(WebApiFixture webApiFixture) : IClassFixture<WebApiFixture>
+public class ServiceStatusTests(EndpointForgeFixture endpointForgeFixture) : IClassFixture<EndpointForgeFixture>
 {
     [Theory]
-    [InlineData("webapi")]
+    [InlineData("EndpointForge")]
     public async Task ResourceHealthEndpointReturnsHealthyWhenResourceIsRunning(string resourceName)
     {
         const string endpointName = "/health";
-        using var httpClient = webApiFixture.Application.CreateHttpClient(resourceName);
+        using var httpClient = endpointForgeFixture.Application.CreateHttpClient(resourceName);
         
         var response = await httpClient.GetAsync(endpointName);
         var body = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
* Change name of Aspire Service for EndpointForge from `webapi` to `EndpointForge` for all occurrences and rename parameters accordingly.