### PR TITLE
Refactor the error response to provide more meaningful information

### DIFF
--- a/EndpointForge.Abstractions/Constants/ErrorStatusCode.cs
+++ b/EndpointForge.Abstractions/Constants/ErrorStatusCode.cs
@@ -1,0 +1,9 @@
+namespace EndpointForge.Abstractions.Constants;
+
+public readonly struct ErrorStatusCode
+{
+    public const string InvalidRequestBody = "INVALID_REQUEST_BODY";
+    public const string RequestBodyInvalidJson = "REQUEST_BODY_INVALID_JSON";
+    public const string RouteConflict = "ROUTE_CONFLICT";
+    public const string InternalServerError = "UNKNOWN_SERVER_ERROR";
+}

--- a/EndpointForge.IntegrationTests/EndpointTests/AddEndpointTests.cs
+++ b/EndpointForge.IntegrationTests/EndpointTests/AddEndpointTests.cs
@@ -18,9 +18,13 @@ public class AddEndpointTests(EndpointForgeFixture endpointForgeFixture) : IClas
     {
         var expectedResponseBody = new
         {
-            StatusCode = HttpStatusCode.BadRequest,
-            Message = "Request body was of an unknown type, empty, or is missing required fields."
+            ErrorStatusCode = "INVALID_REQUEST_BODY",
+            Message = "Request body was of an unknown type, empty, or is missing required fields.",
+            Errors = new [] { 
+                "Request body must not be empty."
+            }
         };
+        
         using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
 
         var response = await httpClient.PostAsync(AddEndpointRoute, null);
@@ -28,6 +32,7 @@ public class AddEndpointTests(EndpointForgeFixture endpointForgeFixture) : IClas
 
         Assert.Multiple(
             () => response.StatusCode.Should().Be(HttpStatusCode.BadRequest),
+            () => response.Headers.Should().ContainKey("X-Trace-Id"),
             () => responseBody.Should().BeEquivalentTo(expectedResponseBody));
     }
 
@@ -36,21 +41,20 @@ public class AddEndpointTests(EndpointForgeFixture endpointForgeFixture) : IClas
     {
         var addEndpointRequest = new
         {
-            Methods = new[]
-            {
-                "GET"
-            }
+            Methods = new[] { "GET" }
         };
+        
         var expectedResponseBody = new
         {
-            StatusCode = HttpStatusCode.BadRequest,
+            ErrorStatusCode = "INVALID_REQUEST_BODY",
             Message = "Request body was of an unknown type, empty, or is missing required fields.",
-            Errors = new []
-            {
+            Errors = new [] 
+            { 
                 "JSON deserialization for type 'EndpointForge.Models.AddEndpointRequest' " +
                 "was missing required properties including: 'Route'."
             }
         };
+        
         using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
@@ -60,6 +64,7 @@ public class AddEndpointTests(EndpointForgeFixture endpointForgeFixture) : IClas
 
         Assert.Multiple(
             () => response.StatusCode.Should().Be(HttpStatusCode.BadRequest),
+            () => response.Headers.Should().ContainKey("X-Trace-Id"),
             () => responseBody.Should().BeEquivalentTo(expectedResponseBody));
     }
 
@@ -70,17 +75,18 @@ public class AddEndpointTests(EndpointForgeFixture endpointForgeFixture) : IClas
         {
             Route = "/test-unprocessable-entity"
         };
+        
         var expectedResponseBody = new
         {
-            StatusCode = HttpStatusCode.BadRequest,
+            ErrorStatusCode = "INVALID_REQUEST_BODY",
             Message = "Request body was of an unknown type, empty, or is missing required fields.",
-            Errors = new[]
-            {
+            Errors = new [] 
+            { 
                 "JSON deserialization for type 'EndpointForge.Models.AddEndpointRequest' " +
                 "was missing required properties including: 'Methods'."
-                
             }
         };
+        
         using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
@@ -90,6 +96,7 @@ public class AddEndpointTests(EndpointForgeFixture endpointForgeFixture) : IClas
 
         Assert.Multiple(
             () => response.StatusCode.Should().Be(HttpStatusCode.BadRequest),
+            () => response.Headers.Should().ContainKey("X-Trace-Id"),
             () => responseBody.Should().BeEquivalentTo(expectedResponseBody));
     }
     
@@ -103,13 +110,14 @@ public class AddEndpointTests(EndpointForgeFixture endpointForgeFixture) : IClas
         };
         var expectedResponseBody = new
         {
-            StatusCode = HttpStatusCode.UnprocessableEntity,
+            ErrorStatusCode = "REQUEST_BODY_INVALID_JSON",
             Message = "Request contains invalid JSON body which cannot be processed.",
-            Errors = new[]
-            {
+            Errors = new [] 
+            { 
                 $"Endpoint request `{nameof(AddEndpointRequest.Methods)}` contains no entries."
             }
         };
+        
         using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
@@ -119,6 +127,7 @@ public class AddEndpointTests(EndpointForgeFixture endpointForgeFixture) : IClas
 
         Assert.Multiple(
             () => response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity),
+            () => response.Headers.Should().ContainKey("X-Trace-Id"),
             () => responseBody.Should().BeEquivalentTo(expectedResponseBody));
     }
 
@@ -132,14 +141,15 @@ public class AddEndpointTests(EndpointForgeFixture endpointForgeFixture) : IClas
         };
         var expectedResponseBody = new
         {
-            StatusCode = HttpStatusCode.UnprocessableEntity,
+            ErrorStatusCode = "REQUEST_BODY_INVALID_JSON",
             Message = "Request contains invalid JSON body which cannot be processed.",
-            Errors = new[]
-            {
+            Errors = new [] 
+            { 
                 $"Endpoint request `{nameof(AddEndpointRequest.Route)}` is empty or whitespace.",
                 $"Endpoint request `{nameof(AddEndpointRequest.Methods)}` contains no entries."
             }
         };
+       
         using var httpClient = endpointForgeFixture.Application.CreateHttpClient(EndpointForgeName);
         var jsonBody = JsonSerializer.Serialize(addEndpointRequest);
         var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
@@ -149,6 +159,7 @@ public class AddEndpointTests(EndpointForgeFixture endpointForgeFixture) : IClas
 
         Assert.Multiple(
             () => response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity),
+            () => response.Headers.Should().ContainKey("X-Trace-Id"),
             () => responseBody.Should().BeEquivalentTo(expectedResponseBody));
     }
     #endregion
@@ -164,7 +175,8 @@ public class AddEndpointTests(EndpointForgeFixture endpointForgeFixture) : IClas
         };
         var expectedResponseBody = new
         {
-            StatusCode = HttpStatusCode.Conflict,
+            ErrorStatusCode = "ROUTE_CONFLICT",
+            Message = "Request contains one or more route conflicts.",
             Errors = new[]
             {
                 "The requested endpoint has already been added for GET method"

--- a/EndpointForge.Models/ErrorResponse.cs
+++ b/EndpointForge.Models/ErrorResponse.cs
@@ -1,3 +1,6 @@
 namespace EndpointForge.Models;
 
-public record ErrorResponse(HttpStatusCode StatusCode, string Message, IEnumerable<string>? Errors);
+public record ErrorResponse(
+    string ErrorStatusCode,
+    string Message, 
+    IEnumerable<string>? Errors);

--- a/EndpointForge.WebApi.Tests/Factories/EndpointResponseFactoryTests.cs
+++ b/EndpointForge.WebApi.Tests/Factories/EndpointResponseFactoryTests.cs
@@ -1,0 +1,68 @@
+using EndpointForge.Abstractions.Constants;
+using EndpointForge.Models;
+using EndpointForge.WebApi.Exceptions;
+using EndpointForge.WebApi.Factories;
+using FluentAssertions;
+
+namespace EndpointForge.WebApi.Tests.Factories;
+
+public class EndpointResponseFactoryTests
+{
+    [Fact]
+    public void When_CreateWithBadRequestEndpointForgeException_Expect_ErrorResponseCreatedWithCorrectValues()
+    {
+        var exception = new BadRequestEndpointForgeException(["test-error"]);
+        var expectedErrorResponse = BuildExpectedErrorResponse(ErrorStatusCode.InvalidRequestBody, exception);
+        
+        var errorResponse = ErrorResponseFactory.Create(exception);
+
+        errorResponse.Should().BeEquivalentTo(expectedErrorResponse);
+    }
+    
+    [Fact]
+    public void When_CreateWithConflictEndpointForgeException_Expect_ErrorResponseCreatedWithCorrectValues()
+    {
+        var exception = new ConflictEndpointForgeException(["test-error"]);
+        var expectedErrorResponse = BuildExpectedErrorResponse(ErrorStatusCode.RouteConflict, exception);
+        
+        var errorResponse = ErrorResponseFactory.Create(exception);
+
+        errorResponse.Should().BeEquivalentTo(expectedErrorResponse);
+    }
+    
+    [Fact]
+    public void When_CreateWithInvalidRequestBodyEndpointForgeException_Expect_ErrorResponseCreatedWithCorrectValues()
+    {
+        var exception = new InvalidRequestBodyEndpointForgeException(["test-error"]);
+        var expectedErrorResponse = BuildExpectedErrorResponse(ErrorStatusCode.RequestBodyInvalidJson, exception);
+        
+        var errorResponse = ErrorResponseFactory.Create(exception);
+
+        errorResponse.Should().BeEquivalentTo(expectedErrorResponse);
+    }
+    
+    [Fact]
+    public void When_CreateWithEndpointForgeException_Expect_ErrorResponseCreatedWithCorrectValues()
+    {
+        var exception = new EndpointForgeException(HttpStatusCode.InternalServerError, "test-message", ["test-error"]);
+        var expectedErrorResponse = BuildExpectedErrorResponse(ErrorStatusCode.InternalServerError, exception);
+        
+        var errorResponse = ErrorResponseFactory.Create(exception);
+
+        errorResponse.Should().BeEquivalentTo(expectedErrorResponse);
+    }
+    
+    [Fact]
+    public void When_CreateWithUnhandledException_Expect_ErrorResponseCreatedWithCorrectValues()
+    {
+        var exception = new Exception("test-message");
+        var expectedErrorResponse = new ErrorResponse(ErrorStatusCode.InternalServerError, "test-message", []);
+        
+        var errorResponse = ErrorResponseFactory.Create(exception);
+
+        errorResponse.Should().BeEquivalentTo(expectedErrorResponse);
+    }
+
+    private static ErrorResponse BuildExpectedErrorResponse(string errorStatusCode, EndpointForgeException exception) =>
+        new(errorStatusCode, exception.Message, exception.Errors);
+}

--- a/EndpointForge.WebApi/Extensions/LoggerExtensions.cs
+++ b/EndpointForge.WebApi/Extensions/LoggerExtensions.cs
@@ -13,15 +13,12 @@ internal static partial class LoggerExtensions
         [LogProperties(OmitReferenceName = true)]
         in ErrorResponse errorResponse);
 
-    [LoggerMessage(LogLevel.Information, "An Error Response has been returned: [{statusCode}] {statusDescription}")]
-    private static partial void ErrorResponseInformation(
-        this ILogger logger,
-        int statusCode,
-        HttpStatusCode statusDescription);
+    [LoggerMessage(LogLevel.Information, "An Error Response has been returned: errorStatusCode={ErrorStatusCode}")]
+    private static partial void ErrorResponseInformation(this ILogger logger, string errorStatusCode);
 
     public static void LogErrorResponse(this ILogger logger, ErrorResponse errorResponse)
     {
-        logger.ErrorResponseInformation((int)errorResponse.StatusCode, errorResponse.StatusCode);
+        logger.ErrorResponseInformation(errorResponse.ErrorStatusCode);
         logger.ErrorResponse(errorResponse);
     }
 

--- a/EndpointForge.WebApi/Factories/ErrorResponseFactory.cs
+++ b/EndpointForge.WebApi/Factories/ErrorResponseFactory.cs
@@ -1,0 +1,33 @@
+using EndpointForge.Abstractions.Constants;
+using EndpointForge.Models;
+using EndpointForge.WebApi.Exceptions;
+
+namespace EndpointForge.WebApi.Factories;
+
+public static class ErrorResponseFactory
+{
+    public static ErrorResponse Create(Exception exception)
+        => exception switch
+        {
+            BadRequestEndpointForgeException e => new ErrorResponse(
+                ErrorStatusCode.InvalidRequestBody,
+                exception.Message,
+                e.Errors),
+            ConflictEndpointForgeException e => new ErrorResponse(
+                ErrorStatusCode.RouteConflict,
+                exception.Message,
+                e.Errors),
+            InvalidRequestBodyEndpointForgeException e => new ErrorResponse(
+                ErrorStatusCode.RequestBodyInvalidJson,
+                exception.Message,
+                e.Errors),
+            EndpointForgeException e => new ErrorResponse(
+                ErrorStatusCode.InternalServerError,
+                exception.Message,
+                e.Errors),
+            _ => new ErrorResponse(
+                ErrorStatusCode.InternalServerError,
+                exception.Message,
+                [])
+        };
+}


### PR DESCRIPTION
* Add static `ErrorStatusCodes` to provide a reusable code when handling these errors.
* Add a header for `X-Trace-Id` to enable better searching for errors in structured logs.
* Move the building of `ErrorResponse` into a factory.
* Update tests and middleware to reflect these changes.