### PR TITLE
Allow capture of `Generator` rules to parameter

### DIFF
--- a/EndpointForge.Abstractions/IEndpointForgeGeneratorRule.cs
+++ b/EndpointForge.Abstractions/IEndpointForgeGeneratorRule.cs
@@ -2,5 +2,5 @@ namespace EndpointForge.Abstractions;
 
 public interface IEndpointForgeGeneratorRule : IEndpointForgeRule
 {
-    void Invoke(StreamWriter streamWriter);
+    bool TryInvoke(StreamWriter streamWriter, out ReadOnlySpan<char> generatedValue);
 }

--- a/EndpointForge.WebApi.Tests/Fakes/FakeGeneratorRule.cs
+++ b/EndpointForge.WebApi.Tests/Fakes/FakeGeneratorRule.cs
@@ -6,5 +6,11 @@ namespace EndpointForge.WebApi.Tests.Fakes;
 internal class FakeGeneratorRule(string type = "", string value = "") : IEndpointForgeGeneratorRule
 {
     public string Type => type;
-    public void Invoke(StreamWriter streamWriter) => streamWriter.Write(value);
+
+    public bool TryInvoke(StreamWriter streamWriter, out ReadOnlySpan<char> generatedValue)
+    {
+        generatedValue = "";
+        streamWriter.Write(value);
+        return true;
+    }
 }

--- a/EndpointForge.WebApi.Tests/Rules/GenerateGuidRuleTests.cs
+++ b/EndpointForge.WebApi.Tests/Rules/GenerateGuidRuleTests.cs
@@ -18,6 +18,20 @@ public class GenerateGuidRuleTests
     }
     
     [Fact]
+    public async Task When_TryInvokeAndGuidIsGenerated_Expect_ReturnsTrue()
+    {
+        var guid = Guid.NewGuid();
+        _stubGuidGenerator.Setup(generator => generator.New).Returns(guid);
+        
+        await using var streamWriter = new StreamWriter(new MemoryStream());
+        
+        var generateGuidRule = new GenerateGuidRule(_stubGuidGenerator.Object);
+        var result = generateGuidRule.TryInvoke(streamWriter, out _);
+        
+        result.Should().BeTrue();
+    }
+    
+    [Fact]
     public async Task When_Invoke_Expect_TheProvidedStreamShouldContainTheProvidedGuid()
     {
         var guid = Guid.NewGuid();
@@ -26,7 +40,7 @@ public class GenerateGuidRuleTests
         await using var streamWriter = new StreamWriter(new MemoryStream());
         
         var generateGuidRule = new GenerateGuidRule(_stubGuidGenerator.Object);
-        generateGuidRule.Invoke(streamWriter);
+        generateGuidRule.TryInvoke(streamWriter, out _);
         
         await streamWriter.FlushAsync();
         streamWriter.BaseStream.Seek(0, SeekOrigin.Begin);
@@ -34,5 +48,21 @@ public class GenerateGuidRuleTests
         var generatedGuid = await streamReader.ReadToEndAsync();
         
         generatedGuid.Should().Be(guid.ToString());
+    }
+    
+    [Fact]
+    public async Task When_TryInvokeAndGuidIsGenerated_Expect_OutValueIsAGuid()
+    {
+        var guid = Guid.NewGuid();
+        _stubGuidGenerator.Setup(generator => generator.New).Returns(guid);
+        
+        await using var streamWriter = new StreamWriter(new MemoryStream());
+        
+        var generateGuidRule = new GenerateGuidRule(_stubGuidGenerator.Object);
+        generateGuidRule.TryInvoke(streamWriter, out var generatedGuid);
+        
+        var parsedGuid = Guid.Parse(generatedGuid);
+        
+        parsedGuid.Should().Be(guid);
     }
 }

--- a/EndpointForge.WebApi/ENDPOINTS.md
+++ b/EndpointForge.WebApi/ENDPOINTS.md
@@ -322,15 +322,16 @@ response body template.
 * * `insert`: A rule which inserts a captured parameter value.
 * `type`: Indicates the type of rule, for instance a `generate` rule might provide a `type` of `guid` for a guid 
 value to be generated
-* 'value': Indicates a value provided for to this rule, and can take a variety of uses and may be omitted by certain 
+* `value`: Indicates a value provided for to this rule, and can take a variety of uses and may be omitted by certain 
 rules.
 
 <br/>
  
 ##### Generate Guid Rule
 
-Placeholder: `{{generate:guid}}`
-Details: This rule is used to generate a unique guid value each time the placeholder is encountered. 
+Placeholder: `{{generate:guid}}` or `{{generate:guid:<parameter name>}}`
+Details: This rule is used to generate a unique guid value each time the placeholder is encountered. When a 
+parameter name is provided, the generated value with stored as parameter and available for use in other rules.
 
 ###### Example
 
@@ -345,7 +346,7 @@ Details: This rule is used to generate a unique guid value each time the placeho
             "response": {
               "statusCode": 200,
               "contentType": "application/json",
-              "body": "First guid: {{generate:guid}}. Second guid: {{generate:guid}}."
+              "body": "1: {{generate:guid}}. 2: {{generate:guid:guid-capture}}. 3: {{insert:parameter:guid-capture}}"
             }
           }'
 ```
@@ -366,11 +367,13 @@ HTTP/1.1 200 OK
 Content-Length: 100
 Content-Type: application/json
 
-First guid: 8c2ed158-1c70-4892-81ab-45a846484576. Second guid: a36ed32d-bfc1-40a5-a619-72cb48fbc7cc.
+1: 3c5a3f1c-a0db-43df-a974-b3e06bbfd755. 2: 9cedb34a-4c09-4dad-8491-cac91c17e0ae. 3: 9cedb34a-4c09-4dad-8491-cac91c17e0ae
+
 ```
 
 As you can see, each time the generate guid rule placeholder was encountered, a different unique guid is generated to 
-replace that placeholder.
+replace that placeholder. When the second guid included a parameter, the insert parameter rule inserted that 
+captured parameter, resulting in `2:` and `3:` being the same guid.
 
 <br/>
 

--- a/EndpointForge.WebApi/Parsers/ResponseBodyParser.cs
+++ b/EndpointForge.WebApi/Parsers/ResponseBodyParser.cs
@@ -70,19 +70,25 @@ public class ResponseBodyParser(
 
         return instruction switch
         {
-            "generate" => TryInvokeGeneratorRule(streamWriter, type),
+            "generate" => TryInvokeGeneratorRule(streamWriter, type, parameterName, parameters),
             "insert" => TryInvokeInsertRule(streamWriter, type, parameterName, parameters),
             _ => false
         };
     }
 
-    private bool TryInvokeGeneratorRule(StreamWriter writer, ReadOnlySpan<char> type)
+    private bool TryInvokeGeneratorRule(
+        StreamWriter writer,
+        ReadOnlySpan<char> type,
+        ReadOnlySpan<char> parameterName,
+        IDictionary<string, string> parameters)
     {
         var rule = ruleFactory.GetRule<IEndpointForgeGeneratorRule>(type);
-        if (rule == null)
+
+        if (rule is null || !rule.TryInvoke(writer, out var generatedValue)) 
             return false;
-            
-        rule.Invoke(writer);
+        
+        if (parameterName is not "")
+            parameters.Add(parameterName.ToString(), generatedValue.ToString());
         return true;
     }
 

--- a/EndpointForge.WebApi/Rules/GenerateGuildRule.cs
+++ b/EndpointForge.WebApi/Rules/GenerateGuildRule.cs
@@ -11,7 +11,7 @@ public class GenerateGuidRule(IGuidGenerator guidGenerator) : IEndpointForgeGene
     private const int GuidCharSize = 36;
     private static readonly ArrayPool<char> CharPool = ArrayPool<char>.Shared;
 
-    public void Invoke(StreamWriter streamWriter)
+    public bool TryInvoke(StreamWriter streamWriter, out ReadOnlySpan<char> generatedValue)
     {
         var guidCharBuffer = CharPool.Rent(GuidCharSize);
 
@@ -19,6 +19,13 @@ public class GenerateGuidRule(IGuidGenerator guidGenerator) : IEndpointForgeGene
         {
             guidGenerator.New.TryFormat(guidCharBuffer, out _);
             streamWriter.Write(guidCharBuffer, 0, GuidCharSize);
+            generatedValue = guidCharBuffer.AsSpan(0, GuidCharSize);
+            return true;
+        }
+        catch
+        {
+            generatedValue = "";
+            return false;
         }
         finally
         {


### PR DESCRIPTION
* Change signature of `EndpointForgeGeneratorRule.Invoke` to `TryInvoke` and output the created guid as a span.
* Update FakeGenerator to respect the new signature
* Update ResponseBodyParser to store that parameter in the parameters dictionary for use.
* Update generator rule integration test to reflect the new parameter option.
* Add unit tests for new functionality
* Update documentation for `Generate Guid` rule.