### PR TITLE
Upgrade to `XUnit.v3`

### DIFF
--- a/EndpointForge.IntegrationTests/EndpointForge.IntegrationTests.csproj
+++ b/EndpointForge.IntegrationTests/EndpointForge.IntegrationTests.csproj
@@ -14,12 +14,8 @@
         <PackageReference Include="FluentAssertions" Version="7.0.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
-        <PackageReference Include="xunit" Version="2.9.2"/>
-        <PackageReference Include="xunit.analyzers" Version="1.18.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+        <PackageReference Include="xunit.v3" Version="1.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/EndpointForge.WebApi.Tests/Attributes/StringEmptyOrWhitespaceInlineDataAttribute.cs
+++ b/EndpointForge.WebApi.Tests/Attributes/StringEmptyOrWhitespaceInlineDataAttribute.cs
@@ -1,9 +1,15 @@
 using System.Reflection;
+using Xunit.v3;
 
 namespace EndpointForge.WebApi.Tests.Attributes;
 
 [ExcludeFromCodeCoverage]
 public class StringEmptyOrWhitespaceInlineDataAttribute : DataAttribute
 {
-    public override IEnumerable<object[]> GetData(MethodInfo testMethod) => [[""], [" "], ["\t"], ["\n"]];
+    public override ValueTask<IReadOnlyCollection<ITheoryDataRow>> GetData(
+        MethodInfo testMethod,
+        DisposalTracker disposalTracker)
+        => new(new List<TheoryDataRow<string>> { "", " ", "\t", "\n" });
+
+    public override bool SupportsDiscoveryEnumeration() => true;
 }

--- a/EndpointForge.WebApi.Tests/Attributes/StringNullEmptyOrWhitespaceInlineDataAttribute.cs
+++ b/EndpointForge.WebApi.Tests/Attributes/StringNullEmptyOrWhitespaceInlineDataAttribute.cs
@@ -1,19 +1,22 @@
 using System.Reflection;
+using Xunit.v3;
 
 namespace EndpointForge.WebApi.Tests.Attributes;
 
 [ExcludeFromCodeCoverage]
 public class StringNullEmptyOrWhitespaceInlineDataAttribute : DataAttribute
-{
-    public override IEnumerable<object?[]> GetData(MethodInfo testMethod)
-    {
-        return
-        [
-            [null, false],
-            ["", false],
-            [" ", false],
-            ["\t", false],
-            ["\n", false]
-        ];
-    }
+{ 
+    public override ValueTask<IReadOnlyCollection<ITheoryDataRow>> GetData(
+        MethodInfo testMethod, 
+        DisposalTracker disposalTracker)
+    => new(new List<TheoryDataRow<string?, bool>>
+        {
+            new(null, false),
+            new("", false),
+            new(" ", false),
+            new("\t", false)
+        });
+
+    public override bool SupportsDiscoveryEnumeration() => true;
+
 }

--- a/EndpointForge.WebApi.Tests/EndpointForge.WebApi.Tests.csproj
+++ b/EndpointForge.WebApi.Tests/EndpointForge.WebApi.Tests.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="FluentValidation.Validators.UnitTestExtension" Version="1.11.0.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
+        <PackageReference Include="xunit.v3" Version="1.0.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
     </ItemGroup>
 


### PR DESCRIPTION
* Upgrade to `XUnit.v3` for better span handling in unit tests in `WebApi.Tests`.
* Update DataAttributes to address breaking change in v3 relating to disposal.