### PR TITLE
Add repeater segment

### DIFF
--- a/EndpointForge.Abstractions/Constants/ParameterType.cs
+++ b/EndpointForge.Abstractions/Constants/ParameterType.cs
@@ -1,9 +1,9 @@
 namespace EndpointForge.Abstractions.Constants;
 
 /// <summary>
-/// Contains types to verify the type of an EndpointForge parameter.
+/// Contains types of EndpointForge parameters
 /// </summary>
-public static class ParameterType
+public static partial class ParameterType
 {
     // ReSharper disable ConvertToConstant.Global
     // These are deliberately `static readonly` and not `const`.  This is so that all consuming assemblies
@@ -36,6 +36,21 @@ public static class ParameterType
     /// <see langword="true" /> if the type is Static; otherwise, <see langword="false" />.
     /// </returns>
     public static bool IsStatic(string type) => Equals(Static, type);
+
+    /// <summary>
+    /// Returns a value that indicates if the provided ReadOnlyCharSpan is a member of this string enum.
+    /// </summary>
+    /// <param name="value">The ReadOnlyCharSpan to be compared.</param>
+    /// <returns>
+    /// <see langword="true" />if the ReadOnlyCharSpan is a member of this string enum; otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool IsMember(ReadOnlySpan<char> value)
+        => value switch
+        {
+            _ when value.SequenceEqual(Header) => true,
+            _ when value.SequenceEqual(Static) => true,
+            _ => false
+        };
     
     /// <summary>
     /// Returns a value that indicates if the EndpointForge parameter types are the same.
@@ -49,4 +64,6 @@ public static class ParameterType
     {
         return ReferenceEquals(typeA, typeB) || StringComparer.OrdinalIgnoreCase.Equals(typeA, typeB);
     }
+    
+    
 }

--- a/EndpointForge.WebApi.Tests/Parsers/ResponseBodyParserTests.cs
+++ b/EndpointForge.WebApi.Tests/Parsers/ResponseBodyParserTests.cs
@@ -1,4 +1,5 @@
 using EndpointForge.Abstractions;
+using EndpointForge.WebApi.Constants;
 using EndpointForge.WebApi.Parsers;
 using EndpointForge.WebApi.Tests.Fakes;
 using FluentAssertions;
@@ -59,10 +60,9 @@ public class ResponseBodyParserTests
     }
     
     [Fact]
-    public async Task When_ProcessResponseBodyWithEmptyPlaceholder_Expect_StreamRemovesThePlaceholder()
+    public async Task When_ProcessResponseBodyWithEmptyPlaceholder_Expect_StreamWriteTheEmptyPlaceholder()
     {
         const string body = "The placeholder instruction '{{}}' is empty.";
-        const string expectedBody = "The placeholder instruction '' is empty.";
         var responseBodyParser = new ResponseBodyParser(StubLogger, StubEndpointForgeRuleFactory);
         var stream = new MemoryStream();
         
@@ -71,7 +71,7 @@ public class ResponseBodyParserTests
         stream.Seek(0, SeekOrigin.Begin);
         var responseBody = await new StreamReader(stream).ReadToEndAsync();
         
-        responseBody.Should().Be(expectedBody);
+        responseBody.Should().Be(body);
     }
     
     [Fact]
@@ -119,10 +119,10 @@ public class ResponseBodyParserTests
     [Fact]
     public async Task When_ProcessResponseBodyWithValidGeneratePlaceholder_Expect_StreamHasPlaceholderReplaced()
     {
-        const string body = "The value '{{generate:test}}' is from a rule.";
+        const string body = "The value '{{generate:guid}}' is from a rule.";
         const string expectedBody = "The value 'test-value' is from a rule.";
         var stubEndpointForgeRuleFactory = new FakeEndpointForgeRuleFactory(
-            new FakeGeneratorRule("test", "test-value"));
+            new FakeGeneratorRule(InstructionType.Guid, "test-value"));
         var responseBodyParser = new ResponseBodyParser(StubLogger, stubEndpointForgeRuleFactory);
         var stream = new MemoryStream();
         
@@ -137,10 +137,10 @@ public class ResponseBodyParserTests
     [Fact]
     public async Task When_ProcessResponseBodyWithTwoValidGeneratePlaceholders_Expect_StreamHasPlaceholdersReplaced()
     {
-        const string body = "The value '{{generate:test}}' is from a rule, as `{{generate:test}}` is also.";
+        const string body = "The value '{{generate:guid}}' is from a rule, as `{{generate:guid}}` is also.";
         const string expectedBody = "The value 'test-value' is from a rule, as `test-value` is also.";
         var stubEndpointForgeRuleFactory = new FakeEndpointForgeRuleFactory(
-            new FakeGeneratorRule("test", "test-value"));
+            new FakeGeneratorRule(InstructionType.Guid, "test-value"));
         var responseBodyParser = new ResponseBodyParser(StubLogger, stubEndpointForgeRuleFactory);
         var stream = new MemoryStream();
         
@@ -222,10 +222,9 @@ public class ResponseBodyParserTests
     }
     
     [Fact]
-    public async Task When_ProcessResponseBodyWithoutParameterAndWithInsertPlaceholder_Expect_StreamHasPlaceholdersReplacedWithNull()
+    public async Task When_ProcessResponseBodyWithoutParameterAndWithInsertPlaceholder_Expect_StreamHasStillHasPlaceholder()
     {
-        const string body = "The parameter is not found and so '{{insert:parameter:test-parameter-1}}' is written.";
-        const string expectedBody = "The parameter is not found and so 'null' is written.";
+        const string body = "Parameter not found so placeholder '{{insert:parameter:test-parameter-1}}' is written.";
         var stubEndpointForgeRuleFactory = new FakeEndpointForgeRuleFactory(
             new FakeInsertRule("parameter"));
         var responseBodyParser = new ResponseBodyParser(StubLogger, stubEndpointForgeRuleFactory);
@@ -240,7 +239,7 @@ public class ResponseBodyParserTests
         stream.Seek(0, SeekOrigin.Begin);
         var responseBody = await new StreamReader(stream).ReadToEndAsync();
         
-        responseBody.Should().Be(expectedBody);
+        responseBody.Should().Be(body);
     }
     #endregion
 }

--- a/EndpointForge.WebApi/Constants/InstructionType.cs
+++ b/EndpointForge.WebApi/Constants/InstructionType.cs
@@ -4,4 +4,15 @@ public static class InstructionType
 {
     public const string Start = "start";
     public const string End = "end";
+    public const string Guid = "guid";
+    public const string Parameter = "parameter";
+
+    public static bool IsInstruction(ReadOnlySpan<char> instruction)
+        => instruction switch
+        {
+            Start or End => true,
+            Guid => true,
+            Parameter => true,
+            _ => false
+        };
 }

--- a/EndpointForge.WebApi/Constants/InstructionType.cs
+++ b/EndpointForge.WebApi/Constants/InstructionType.cs
@@ -1,0 +1,7 @@
+namespace EndpointForge.WebApi.Constants;
+
+public static class InstructionType
+{
+    public const string Start = "start";
+    public const string End = "end";
+}

--- a/EndpointForge.WebApi/Constants/RuleType.cs
+++ b/EndpointForge.WebApi/Constants/RuleType.cs
@@ -1,0 +1,6 @@
+namespace EndpointForge.WebApi.Constants;
+
+public static class RuleType
+{
+    public const string Repeater = "repeater";
+}

--- a/EndpointForge.WebApi/Constants/RuleType.cs
+++ b/EndpointForge.WebApi/Constants/RuleType.cs
@@ -2,5 +2,17 @@ namespace EndpointForge.WebApi.Constants;
 
 public static class RuleType
 {
-    public const string Repeater = "repeater";
+    public const string Insert = "insert";
+    public const string Repeat = "repeat";
+    public const string Generate = "generate";
+
+    public static bool IsRule(ReadOnlySpan<char> ruleType)
+        => ruleType switch
+        {
+            Repeat => true,
+            Generate => true,
+            Insert => true,
+            _ => false
+        };
+
 }

--- a/EndpointForge.WebApi/Extensions/PlaceholderDetailsExtensions.cs
+++ b/EndpointForge.WebApi/Extensions/PlaceholderDetailsExtensions.cs
@@ -1,0 +1,11 @@
+using EndpointForge.WebApi.Constants;
+using EndpointForge.WebApi.Models;
+
+namespace EndpointForge.WebApi.Extensions;
+
+public static class PlaceholderDetailsExtensions
+{
+    public static bool IsMatchingRepeatEnd(this PlaceholderDetails details, ReadOnlySpan<char> name)
+        => details is { Rule: RuleType.Repeat, Instruction: InstructionType.End } 
+           && details.Name.SequenceEqual(name);
+}

--- a/EndpointForge.WebApi/Extensions/ReadOnlySpanExtensions.cs
+++ b/EndpointForge.WebApi/Extensions/ReadOnlySpanExtensions.cs
@@ -1,0 +1,44 @@
+namespace EndpointForge.WebApi.Extensions;
+
+public static class ReadOnlySpanExtensions
+{
+    public static bool IsStartOfPlaceholderEnd(this ReadOnlySpan<char> segmentSpan, int readPosition)
+        => readPosition + 1 != segmentSpan.Length
+           && segmentSpan[readPosition] is '}'
+           && segmentSpan[readPosition + 1] is '}';
+
+    public static bool IsStartOfPlaceholderBegin(this ReadOnlySpan<char> segmentSpan, int readPosition)
+        => readPosition + 1 != segmentSpan.Length
+           && segmentSpan[readPosition] is '{'
+           && segmentSpan[readPosition + 1] is '{';
+
+    public static ReadOnlySpan<char> ExtractPlaceholder(this ReadOnlySpan<char> segmentSpan, ref int readPosition)
+    {
+        var placeholderContentStartPosition = readPosition;
+            
+        // if the end of the placeholder is immediately after the placeholder (`{{}}`) then this is not a
+        // valid placeholder and should be written.
+        if (segmentSpan.IsStartOfPlaceholderEnd(readPosition))
+        {
+            // set the current read position to after the end of the placeholder.
+            readPosition += 2;
+            return ReadOnlySpan<char>.Empty;
+        }
+        
+        while (!segmentSpan.IsStartOfPlaceholderEnd(readPosition))
+        {
+            readPosition++;
+            if (readPosition == segmentSpan.Length - 1)
+                throw new Exception("Placeholder end marker not found");
+            if (segmentSpan.IsStartOfPlaceholderBegin(readPosition))
+                throw new Exception("New placeholder start marker found before end of current placeholder");
+        }
+        
+        var placeholder = segmentSpan[placeholderContentStartPosition..readPosition];
+
+        //set current read position to the first character after the placeholder end marker
+        readPosition += 2;
+
+        return placeholder;
+    }
+}

--- a/EndpointForge.WebApi/Models/PlaceholderDetails.cs
+++ b/EndpointForge.WebApi/Models/PlaceholderDetails.cs
@@ -1,0 +1,64 @@
+using EndpointForge.WebApi.Constants;
+
+namespace EndpointForge.WebApi.Models;
+
+public ref struct PlaceholderDetails
+{
+    public ReadOnlySpan<char> Rule;
+    public ReadOnlySpan<char> Instruction;
+    public ReadOnlySpan<char> Name;
+    public ReadOnlySpan<char> Values;
+
+    private PlaceholderDetails(
+        ReadOnlySpan<char> rule, 
+        ReadOnlySpan<char> instruction, 
+        ReadOnlySpan<char> name,
+        ReadOnlySpan<char> values)
+    {
+        Rule = rule;
+        Instruction = instruction;
+        Name = name;
+        Values = values;
+    }
+
+    public static bool TryParse(ReadOnlySpan<char> placeholderSpan, out PlaceholderDetails details)
+    {
+        var placeholderSplitEnumerator = placeholderSpan.Split(':');
+        details = default;
+        
+        if (!placeholderSplitEnumerator.MoveNext())
+            return false;
+        var rule = placeholderSpan[placeholderSplitEnumerator.Current];
+        if (!RuleType.IsRule(rule))
+        {
+            return false;
+        }
+        
+        if (!placeholderSplitEnumerator.MoveNext())
+            return false;
+        var instruction = placeholderSpan[placeholderSplitEnumerator.Current];
+        if (!InstructionType.IsInstruction(instruction))
+        {
+            return false;
+        }
+        
+        
+        if (!placeholderSplitEnumerator.MoveNext())
+        {
+            details = new PlaceholderDetails(rule, instruction, ReadOnlySpan<char>.Empty, ReadOnlySpan<char>.Empty);
+            return true;
+        }
+        var name = placeholderSpan[placeholderSplitEnumerator.Current];
+
+        
+        if (!placeholderSplitEnumerator.MoveNext())
+        {
+            details = new PlaceholderDetails(rule, instruction, name, ReadOnlySpan<char>.Empty);
+            return true;
+        }
+        var values = placeholderSpan[placeholderSplitEnumerator.Current];
+        
+        details =  new PlaceholderDetails(rule, instruction, name, values);
+        return true;
+    }
+}

--- a/EndpointForge.WebApi/Rules/GenerateGuildRule.cs
+++ b/EndpointForge.WebApi/Rules/GenerateGuildRule.cs
@@ -1,11 +1,11 @@
 using EndpointForge.Abstractions;
+using EndpointForge.WebApi.Constants;
 
 namespace EndpointForge.WebApi.Rules;
 
 public class GenerateGuidRule(IGuidGenerator guidGenerator) : IEndpointForgeGeneratorRule
 {
-    private const string RuleType = "guid";
-    public string Type => RuleType;
+    public string Type => InstructionType.Guid;
     
 
     private const int GuidCharSize = 36;

--- a/EndpointForge.WebApi/Rules/InsertParameterRule.cs
+++ b/EndpointForge.WebApi/Rules/InsertParameterRule.cs
@@ -1,11 +1,11 @@
 using EndpointForge.Abstractions;
+using EndpointForge.WebApi.Constants;
 
 namespace EndpointForge.WebApi.Rules;
 
 public class InsertParameterRule : IEndpointForgeInsertRule
 {
-    private const string RuleType = "parameter";
-    public string Type => RuleType;
+    public string Type => InstructionType.Parameter;
 
     public void Invoke(StreamWriter streamWriter, ReadOnlySpan<char> value) => streamWriter.Write(value);
 }


### PR DESCRIPTION
* Add constant types for `RuleType` and `InstructionType`
* Update `ParameterType` handling.
* Add `PlaceholderDetails` span and TryParse method
* Add extension for to check if a placeholder is a matching `repeat:end` placeholder for the currently being processed repeater
* Add `ReadOnlySpan<char>` extensions to check if the start and end of a placeholder is found and to extract the placeholder content from the placeholder.
* Update `ResponseBodyParser` to handle repeater segments.
* Update and add tests integration tests